### PR TITLE
AlkEthOH interaction-typing task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,6 @@ parm_at_Frosst.tgz
 .DS_Store
 
 # AlkEthOH dataset
-hgfp/data/alkethoh/AlkEthOH_rings.npz
-hgfp/data/alkethoh/AlkEthOH_rings.smi
-hgfp/data/alkethoh/AlkEthOH_rings_offmols.pkl
+#hgfp/data/alkethoh/AlkEthOH_rings.npz
+#hgfp/data/alkethoh/AlkEthOH_rings.smi
+#hgfp/data/alkethoh/AlkEthOH_rings_offmols.pkl

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ parm_at_Frosst.tgz
 
 
 .DS_Store
+
+# AlkEthOH dataset
+hgfp/data/alkethoh/AlkEthOH_rings.npz
+hgfp/data/alkethoh/AlkEthOH_rings.smi

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ dmypy.json
 
 # Parm@Frosst download
 parm_at_Frosst.tgz
+
+# PyCharm
+.idea
+
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ parm_at_Frosst.tgz
 # AlkEthOH dataset
 hgfp/data/alkethoh/AlkEthOH_rings.npz
 hgfp/data/alkethoh/AlkEthOH_rings.smi
+hgfp/data/alkethoh/AlkEthOH_rings_offmols.pkl

--- a/hgfp/data/alkethoh/.gitattributes
+++ b/hgfp/data/alkethoh/.gitattributes
@@ -1,0 +1,3 @@
+AlkEthOH_rings.npz filter=lfs diff=lfs merge=lfs -text
+AlkEthOH_rings.smi filter=lfs diff=lfs merge=lfs -text
+AlkEthOH_rings_offmols.pkl filter=lfs diff=lfs merge=lfs -text

--- a/hgfp/data/alkethoh/AlkEthOH_rings.npz
+++ b/hgfp/data/alkethoh/AlkEthOH_rings.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6920763db4746288aac84c523e47dca9a94bd28f4572877a54e721bc3a3a5e
+size 2815911

--- a/hgfp/data/alkethoh/AlkEthOH_rings.smi
+++ b/hgfp/data/alkethoh/AlkEthOH_rings.smi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a715c40e4cd31cdf6325de72e67c0f4e030b375918bfde49e04124c1ecb4b7d
+size 34105

--- a/hgfp/data/alkethoh/AlkEthOH_rings_offmols.pkl
+++ b/hgfp/data/alkethoh/AlkEthOH_rings_offmols.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dfbac702a9a420ae954983c8664cfcd652eec16d89db133ff06300814189ed0
+size 2032592

--- a/hgfp/data/alkethoh/baseline_typers.py
+++ b/hgfp/data/alkethoh/baseline_typers.py
@@ -1,0 +1,201 @@
+import numpy as np
+from hgfp.data.alkethoh.label_molecules import get_labeled_atoms
+
+# baseline rule-based classifiers
+
+def get_elements(mol, atom_indices):
+    elements = np.array([a.element.atomic_number for a in mol.atoms])
+    return elements[atom_indices]
+
+
+def get_element_tuples(mol, atom_indices):
+    """return the same tuple regardless of whether atom_indices are running forward or backward
+
+    for torsions, get_element_tuples(i,j,k,l)
+
+    """
+    return [min(tuple(t), tuple(t[::-1])) for t in get_elements(mol, atom_indices)]
+
+def is_carbon(atom):
+    return atom.atomic_number == 6
+
+
+def is_hydrogen(atom):
+    return atom.atomic_number == 1
+
+
+def is_oxygen(atom):
+    return atom.atomic_number == 8
+
+
+def neighboring_carbons(atom):
+    return list(filter(is_carbon, atom.bonded_atoms))
+
+
+def neighboring_hydrogens(atom):
+    return list(filter(is_hydrogen, atom.bonded_atoms))
+
+
+def neighboring_oxygens(atom):
+    return list(filter(is_oxygen, atom.bonded_atoms))
+
+
+def classify_atom(atom):
+    if is_hydrogen(atom):
+        carbon_neighborhood = neighboring_carbons(atom)
+        if len(carbon_neighborhood) == 1:
+            N = len(neighboring_oxygens(carbon_neighborhood[0]))
+            if N >= 3:
+                return 5
+            elif N == 2:
+                return 4
+            elif N == 1:
+                return 3
+            else:
+                return 2
+        else:
+            return 12
+    elif is_carbon(atom):
+        return 16
+    elif is_oxygen(atom):
+        if len(neighboring_hydrogens(atom)) == 1:
+            return 19
+        else:
+            return 18
+
+
+def classify_atoms(mol):
+    return np.array([classify_atom(a) for a in mol.atoms])
+
+
+def classify_bond(atom1, atom2):
+    # both carbon
+    if is_carbon(atom1) and is_carbon(atom2):
+        return 1
+
+    # one is carbon and the other oxygen, regardless of order
+    elif (is_carbon(atom1) and is_oxygen(atom2)) or (is_carbon(atom2) and is_oxygen(atom1)):
+
+        # need to catch *which* one was oxygen
+        if is_oxygen(atom1):
+            oxygen = atom1
+        else:
+            oxygen = atom2
+
+        H = len(neighboring_hydrogens(oxygen))
+        X = len(list(oxygen.bonded_atoms))
+
+        if (X == 2) and (H == 0):
+            return 15
+        else:
+            return 14
+
+    # one is carbon and the other hydrogen, regardless of order
+    elif (is_carbon(atom1) and is_hydrogen(atom2)) or (is_carbon(atom2) and is_hydrogen(atom1)):
+        return 83
+
+    # both oxygen
+    elif is_oxygen(atom1) and is_oxygen(atom2):
+        return 40
+
+    # oxygen-hydrogen
+    else:
+        return 87
+
+def classify_bonds(mol, bond_inds):
+    atoms = list(mol.atoms)
+    return np.array([classify_bond(atoms[i], atoms[j]) for (i,j) in bond_inds])
+
+
+def classify_angle(atom1, atom2, atom3):
+    if is_hydrogen(atom1) and is_hydrogen(atom3):
+        return 2
+    elif is_oxygen(atom2):
+        return 27
+    else:
+        return 1
+
+
+def classify_angles(mol, angle_inds):
+    return np.array([
+        classify_angle(mol.atoms[i], mol.atoms[j], mol.atoms[k]) for (i, j, k) in angle_inds])
+
+
+# simple torsion classifier: look at element identities of atom1, atom2, atom3, and atom4
+from collections import defaultdict
+
+def learn_torsion_lookup():
+    # TODO: collect rest of missing logic...
+    torsion_tuple_counts = defaultdict(lambda: defaultdict(lambda: 0))
+    for i in range(len(mols)):
+        torsion_inds, torsion_labels = get_labeled_torsions(labeled_mols[i])
+        element_tuples = get_element_tuples(mols[i], torsion_inds)
+        for j in range(len(torsion_labels)):
+            torsion_tuple_counts[element_tuples[j]][torsion_labels[j]] += 1
+
+
+
+# the learned classifier
+torsion_prediction_dict = {
+    (6, 6, 6, 8): 1, (1, 6, 6, 6): 4, (1, 8, 6, 6): 85, (6, 6, 8, 6): 87,
+    (6, 8, 6, 8): 89, (1, 6, 8, 6): 86, (8, 6, 6, 8): 5, (1, 6, 6, 8): 9,
+    (1, 8, 6, 8): 84, (1, 6, 6, 1): 3, (1, 6, 8, 1): 84, (6, 6, 6, 6): 2,
+    (6, 6, 8, 8): 86, (6, 8, 8, 6): 116, (1, 6, 8, 8): 86, (8, 6, 8, 8): 86,
+    (6, 8, 8, 8): 116
+}
+
+
+def classify_torsions(mol, torsion_inds):
+    return np.array([torsion_prediction_dict[t] for t in get_element_tuples(mol, torsion_inds)])
+
+
+if __name__ == '__main__':
+    from pickle import load
+    with open('AlkEthOH_rings_offmols.pkl', 'rb') as f:
+        mols = load(f)
+
+    label_dict = np.load('AlkEthOH_rings.npz')
+
+    # atoms
+    n_correct, n_total = 0, 0
+    for name in mols:
+        mol = mols[name]
+        inds, labels = label_dict[f'{name}_atom_inds'], label_dict[f'{name}_atom_labels']
+
+        ## TODO: track this down
+        #n_correct += sum(classify_atoms(mols[name])[inds] == labels) # problem: atom_inds and atom_labels aren't the same shape!
+
+        # TODO: update classify_atoms signature to accept indices, just like bonds/angles/torsions
+        n_correct += sum(classify_atoms(mols[name]) == labels)
+        n_total += mol.n_atoms
+    print('atoms: ', n_correct, n_total)
+
+    # bonds
+    n_correct, n_total = 0, 0
+    for name in mols:
+        mol = mols[name]
+        inds, labels = label_dict[f'{name}_bond_inds'], label_dict[f'{name}_bond_labels']
+
+        n_correct += sum(classify_bonds(mols[name], inds) == labels)
+        n_total += len(labels)
+    print('bonds: ', n_correct, n_total)
+
+    # angles
+    n_correct, n_total = 0, 0
+    for name in mols:
+        mol = mols[name]
+        inds, labels = label_dict[f'{name}_angle_inds'], label_dict[f'{name}_angle_labels']
+
+        n_correct += sum(classify_angles(mols[name], inds) == labels)
+        n_total += len(labels)
+    print('angles: ', n_correct, n_total)
+
+    # torsions
+    n_correct, n_total = 0, 0
+    for name in mols:
+        mol = mols[name]
+        inds, labels = label_dict[f'{name}_torsion_inds'], label_dict[f'{name}_torsion_labels']
+
+        n_correct += sum(classify_torsions(mols[name], inds) == labels)
+        n_total += len(labels)
+    print('torsions: ', n_correct, n_total)

--- a/hgfp/data/alkethoh/label_molecules.py
+++ b/hgfp/data/alkethoh/label_molecules.py
@@ -51,7 +51,7 @@ from functools import partial
 get_labeled_atoms = partial(get_inds_and_labels, type_name='vdW')
 get_labeled_bonds = partial(get_inds_and_labels, type_name='Bonds')
 get_labeled_angles = partial(get_inds_and_labels, type_name='Angles')
-get_labeled_torsions = partial(get_inds_and_labels, type_name='Torsions')
+get_labeled_torsions = partial(get_inds_and_labels, type_name='ProperTorsions')
 
 if __name__ == '__main__':
     # download, if it isn't already present

--- a/hgfp/data/alkethoh/label_molecules.py
+++ b/hgfp/data/alkethoh/label_molecules.py
@@ -63,16 +63,19 @@ if __name__ == '__main__':
         ring_smiles = [l.split()[0] for l in f.readlines()]
     with open(alkethoh_local_path, 'r') as f:
         ring_names = [l.split()[1] for l in f.readlines()]
-    mols = [Molecule.from_smiles(s, allow_undefined_stereo=True) for s in ring_smiles]
+
+    mols = dict()
+    for i in range(len(ring_names)):
+        mols[ring_names[i]] = Molecule.from_smiles(ring_smiles[i], allow_undefined_stereo=True)
 
     with open('AlkEthOH_rings_offmols.pkl', 'wb') as f:
         dump(mols, f)
 
     # Label molecules using forcefield
     # Takes about ~200ms per molecule -- can do ~1000 molecules in ~5-6 minutes, sequentially
-    labeled_mols = []
-    for mol in tqdm(mols):
-        labeled_mols.append(label_mol(mol))
+    labeled_mols = dict()
+    for name in tqdm(ring_names):
+        labeled_mols[name] = label_mol(mols[name])
 
     label_dict = dict()
     for (name, labeled_mol) in zip(ring_names, labeled_mols):

--- a/hgfp/data/alkethoh/label_molecules.py
+++ b/hgfp/data/alkethoh/label_molecules.py
@@ -2,6 +2,7 @@
 
 import os
 import urllib
+from pickle import dump
 
 import numpy as np
 from openforcefield.topology import Molecule
@@ -63,6 +64,9 @@ if __name__ == '__main__':
     with open(alkethoh_local_path, 'r') as f:
         ring_names = [l.split()[1] for l in f.readlines()]
     mols = [Molecule.from_smiles(s, allow_undefined_stereo=True) for s in ring_smiles]
+
+    with open('AlkEthOH_rings_offmols.pkl', 'wb') as f:
+        dump(mols, f)
 
     # Label molecules using forcefield
     # Takes about ~200ms per molecule -- can do ~1000 molecules in ~5-6 minutes, sequentially

--- a/hgfp/data/alkethoh/label_molecules.py
+++ b/hgfp/data/alkethoh/label_molecules.py
@@ -1,0 +1,98 @@
+"""label every molecule in AlkEthOH rings set"""
+
+import os
+import urllib
+
+import numpy as np
+from openforcefield.topology import Molecule
+from openforcefield.typing.engines.smirnoff import ForceField
+from tqdm import tqdm
+
+alkethoh_url = 'https://raw.githubusercontent.com/openforcefield/open-forcefield-data/e07bde16c34a3fa1d73ab72e2b8aeab7cd6524df/Model-Systems/AlkEthOH_distrib/AlkEthOH_rings.smi'
+alkethoh_local_path = 'AlkEthOH_rings.smi'
+
+
+def download_alkethoh():
+    if not os.path.exists(alkethoh_local_path):
+        with urllib.request.urlopen(alkethoh_url) as response:
+            smi = response.read()
+        with open(alkethoh_local_path, 'wb') as f:
+            f.write(smi)
+
+
+# Load the OpenFF "Parsley" force field. -- pick unconstrained so that Hbond stretches are sampled...
+forcefield = ForceField('openff_unconstrained-1.0.0.offxml')
+
+
+## loading molecules
+# TODO: replace mol_from_smiles with something that reads the mol2 files directly...
+def mol_from_smiles(smiles):
+    mol = Molecule.from_smiles(smiles, hydrogens_are_explicit=False, allow_undefined_stereo=True)
+    return mol
+
+
+## labeling molecules
+def label_mol(mol):
+    return forcefield.label_molecules(mol.to_topology())[0]
+
+
+def get_inds_and_labels(labeled_mol, type_name='vdW'):
+    terms = labeled_mol[type_name]
+    inds = np.array(list(terms.keys()))
+    labels = np.array([int(term.id[1:]) for term in terms.values()])
+
+    assert (len(inds) == len(labels))
+
+    return inds, labels
+
+
+from functools import partial
+
+get_labeled_atoms = partial(get_inds_and_labels, type_name='vdW')
+get_labeled_bonds = partial(get_inds_and_labels, type_name='Bonds')
+get_labeled_angles = partial(get_inds_and_labels, type_name='Angles')
+get_labeled_torsions = partial(get_inds_and_labels, type_name='Torsions')
+
+if __name__ == '__main__':
+    # download, if it isn't already present
+    download_alkethoh()
+
+    # load molecules
+    with open(alkethoh_local_path, 'r') as f:
+        ring_smiles = [l.split()[0] for l in f.readlines()]
+    with open(alkethoh_local_path, 'r') as f:
+        ring_names = [l.split()[1] for l in f.readlines()]
+    mols = [Molecule.from_smiles(s, allow_undefined_stereo=True) for s in ring_smiles]
+
+    # Label molecules using forcefield
+    # Takes about ~200ms per molecule -- can do ~1000 molecules in ~5-6 minutes, sequentially
+    labeled_mols = []
+    for mol in tqdm(mols):
+        labeled_mols.append(label_mol(mol))
+
+    label_dict = dict()
+    for (name, labeled_mol) in zip(ring_names, labeled_mols):
+        label_dict[name + '_atom_inds'], label_dict[name + '_atom_labels'] = get_labeled_atoms(labeled_mol)
+        label_dict[name + '_bond_inds'], label_dict[name + '_bond_labels'] = get_labeled_bonds(labeled_mol)
+        label_dict[name + '_angle_inds'], label_dict[name + '_angle_labels'] = get_labeled_angles(labeled_mol)
+        label_dict[name + '_torsion_inds'], label_dict[name + '_torsion_labels'] = get_labeled_torsions(labeled_mol)
+
+    # save to compressed array
+    description = f"""
+    Each of the molecules in AlkEthOH_rings.smi
+        {alkethoh_url}
+    
+    is labeled according to the forcefield `openff_unconstrained-1.0.0.offxml`:
+        https://github.com/openforcefield/openforcefields/blob/master/openforcefields/offxml/openff_unconstrained-1.0.0.offxml
+    
+    Keys are of the form 
+        <name>_<atom|bond|angle|torsion>_<inds|labels>
+        
+        such as 'AlkEthOH_r0_atom_inds' or 'AlkEthOH_r0_torsion_labels'
+        
+    and values are integer arrays
+    """
+
+    np.savez_compressed('AlkEthOH_rings.npz',
+                        description=description,
+                        **label_dict)

--- a/hgfp/data/alkethoh/pytorch_datasets.py
+++ b/hgfp/data/alkethoh/pytorch_datasets.py
@@ -1,0 +1,69 @@
+"""provide a pytorch dataset views of the interaction typing dataset"""
+
+from pickle import load
+from typing import Tuple
+
+import numpy as np
+from openforcefield.topology import Molecule
+from torch import tensor, Tensor
+from torch.utils.data.dataset import Dataset
+
+
+class AlkEthOHDataset(Dataset):
+    def __init__(self):
+        with open('AlkEthOH_rings_offmols.pkl', 'rb') as f:
+            self._mols = load(f)
+
+        self._label_dict = np.load('AlkEthOH_rings.npz')
+
+    def _get_inds(self, index: str, type_name: str) -> Tensor:
+        return tensor(self._label_dict[f'{index}_{type_name}_inds'])
+
+    def _get_labels(self, index: str, type_name:str) -> Tensor:
+        return tensor(self._label_dict[f'{index}_{type_name}_labels'])
+
+    def _get_mol_inds_labels(self, index: str, type_name: str) -> Tuple[Molecule, Tensor, Tensor]:
+        assert (index in self._mols)
+        mol = self._mols[index]
+        inds = self._get_inds(index, type_name)
+        labels = self._get_labels(index, type_name)
+        return mol, inds, labels
+
+
+class AlkEthOHAtomTypesDataset(AlkEthOHDataset):
+
+    def __getitem__(self, index) -> Tuple[Molecule, Tensor, Tensor]:
+        return self._get_mol_inds_labels(index, 'atom')
+
+
+class AlkEthOHBondTypesDataset(AlkEthOHDataset):
+
+    def __getitem__(self, index) -> Tuple[Molecule, Tensor, Tensor]:
+        return self._get_mol_inds_labels(index, 'bond')
+
+
+class AlkEthOHAngleTypesDataset(AlkEthOHDataset):
+
+    def __getitem__(self, index) -> Tuple[Molecule, Tensor, Tensor]:
+        return self._get_mol_inds_labels(index, 'angle')
+
+
+class AlkEthOHTorsionTypesDataset(AlkEthOHDataset):
+
+    def __getitem__(self, index) -> Tuple[Molecule, Tensor, Tensor]:
+        return self._get_mol_inds_labels(index, 'torsion')
+
+
+if __name__ == '__main__':
+
+    # TODO: move this from __main__ into doctests
+
+    index = 'AlkEthOH_r0'
+    # atoms
+    print(AlkEthOHAtomTypesDataset()[index])
+    # bonds
+    print(AlkEthOHBondTypesDataset()[index])
+    # angles
+    print(AlkEthOHAngleTypesDataset()[index])
+    # torsions
+    print(AlkEthOHTorsionTypesDataset()[index])

--- a/hgfp/data/alkethoh/pytorch_datasets.py
+++ b/hgfp/data/alkethoh/pytorch_datasets.py
@@ -15,18 +15,19 @@ class AlkEthOHDataset(Dataset):
             self._mols = load(f)
 
         self._label_dict = np.load('AlkEthOH_rings.npz')
+        self._mol_names = sorted(list(self._mols.keys()))
 
-    def _get_inds(self, index: str, type_name: str) -> Tensor:
-        return tensor(self._label_dict[f'{index}_{type_name}_inds'])
+    def _get_inds(self, mol_name: str, type_name: str) -> Tensor:
+        return tensor(self._label_dict[f'{mol_name}_{type_name}_inds'])
 
-    def _get_labels(self, index: str, type_name:str) -> Tensor:
-        return tensor(self._label_dict[f'{index}_{type_name}_labels'])
+    def _get_labels(self, mol_name: str, type_name: str) -> Tensor:
+        return tensor(self._label_dict[f'{mol_name}_{type_name}_labels'])
 
-    def _get_mol_inds_labels(self, index: str, type_name: str) -> Tuple[Molecule, Tensor, Tensor]:
-        assert (index in self._mols)
-        mol = self._mols[index]
-        inds = self._get_inds(index, type_name)
-        labels = self._get_labels(index, type_name)
+    def _get_mol_inds_labels(self, index: int, type_name: str) -> Tuple[Molecule, Tensor, Tensor]:
+        mol_name = self._mol_names[index]
+        mol = self._mols[mol_name]
+        inds = self._get_inds(mol_name, type_name)
+        labels = self._get_labels(mol_name, type_name)
         return mol, inds, labels
 
 
@@ -55,15 +56,13 @@ class AlkEthOHTorsionTypesDataset(AlkEthOHDataset):
 
 
 if __name__ == '__main__':
-
     # TODO: move this from __main__ into doctests
 
-    index = 'AlkEthOH_r0'
     # atoms
-    print(AlkEthOHAtomTypesDataset()[index])
+    print(AlkEthOHAtomTypesDataset()[0])
     # bonds
-    print(AlkEthOHBondTypesDataset()[index])
+    print(AlkEthOHBondTypesDataset()[0])
     # angles
-    print(AlkEthOHAngleTypesDataset()[index])
+    print(AlkEthOHAngleTypesDataset()[0])
     # torsions
-    print(AlkEthOHTorsionTypesDataset()[index])
+    print(AlkEthOHTorsionTypesDataset()[0])


### PR DESCRIPTION
Add datasets for tasks of classifying atom/bond/angle/torsion types for molecules in AlkEthOH rings set, and provide simple rule-based baselines for each task.

Done:
- [x] Add script to download AlkEthOH rings dataset, label atom- and interaction-types using OpenFF 1.0.0 Parsley forcefield, and save discrete labels. (Tracked using Git LFS.)
- [x] Add PyTorch Dataset interfaces to `AlkEthOH{Atom|Bond|Angle|Torsion}TypesDataset`s
- [x] Add simple rule-based baseline classifiers for {atom|bond|angle|torsion}-typing tasks on this set. (Each looks only at element identities up to 2 hops away, achieving accuracies of 100% for atoms, 100% for bonds, ~97% for angles, ~99% for torsions.)

Todo: 
- [ ] Update paths from `hfgp` to `espaloma`
- [ ] Update tests, make sure resources can be found (currently using relative paths, should use `pkg_resources.resource_filename`s)
- [ ] Discuss with @yuanqing-wang whether PyTorch Dataset interface is suitable, make adjustments