### PR TITLE
Dihedral geometry tests

### DIFF
--- a/espaloma/mm/tests/test_dihedral.py
+++ b/espaloma/mm/tests/test_dihedral.py
@@ -1,7 +1,55 @@
 import numpy as np
 import numpy.testing as npt
-import pytest
 import torch
+
+
+def _sample_unit_circle(n_samples: int = 1) -> np.ndarray:
+    """
+    >>> np.isclose(np.linalg.norm(_sample_unit_circle(1)), 1)
+    True
+
+    """
+    theta = np.random.rand(n_samples) * 2 * np.pi
+    x = np.cos(theta)
+    y = np.sin(theta)
+    xy = np.array([x, y]).T
+    assert (xy.shape == (n_samples, 2))
+    return xy
+
+
+def _sample_four_particle_torsion_scan(n_samples: int = 1) -> np.ndarray:
+    """Generate n_samples random configurations of a 4-particle system abcd where
+    * distances ab, bc, cd are constant,
+    * angles abc, bcd are constant
+    * dihedral angle abcd is uniformly distributed in [0, 2pi]
+
+    Returns
+    -------
+    xyz : np.ndarray, shape = (n_samples, 4, 3)
+
+    Notes
+    -----
+    * Positions of a,b,c are constant, and x-coordinate of d is constant.
+        To be more exacting, could add random displacements and rotations.
+    """
+    a = (-3, -1, 0)
+    b = (-2, 0, 0)
+    c = (-1, 0, 0)
+    d = (0, 1, 0)
+
+    # form one 3D configuration
+    conf = np.array([a, b, c, d])
+    assert (conf.shape == (4, 3))
+
+    # make n_samples copies
+    xyz = np.array([conf] * n_samples, dtype=float)
+    assert (xyz.shape == (n_samples, 4, 3))
+
+    # assign y and z coordinates of particle d to unit-circle samples
+    xyz[:, 3, 1:] = _sample_unit_circle(n_samples)
+
+    return xyz
+
 
 
 def test_dihedral_vectors():

--- a/espaloma/mm/tests/test_dihedral.py
+++ b/espaloma/mm/tests/test_dihedral.py
@@ -1,57 +1,8 @@
-import numpy as np
 import numpy.testing as npt
 import torch
 
 import espaloma as esp
-
-
-def _sample_unit_circle(n_samples: int = 1) -> np.ndarray:
-    """
-    >>> np.isclose(np.linalg.norm(_sample_unit_circle(1)), 1)
-    True
-
-    """
-    theta = np.random.rand(n_samples) * 2 * np.pi
-    x = np.cos(theta)
-    y = np.sin(theta)
-    xy = np.array([x, y]).T
-    assert (xy.shape == (n_samples, 2))
-    return xy
-
-
-def _sample_four_particle_torsion_scan(n_samples: int = 1) -> np.ndarray:
-    """Generate n_samples random configurations of a 4-particle system abcd where
-    * distances ab, bc, cd are constant,
-    * angles abc, bcd are constant
-    * dihedral angle abcd is uniformly distributed in [0, 2pi]
-
-    Returns
-    -------
-    xyz : np.ndarray, shape = (n_samples, 4, 3)
-
-    Notes
-    -----
-    * Positions of a,b,c are constant, and x-coordinate of d is constant.
-        To be more exacting, could add random displacements and rotations.
-    """
-    a = (-3, -1, 0)
-    b = (-2, 0, 0)
-    c = (-1, 0, 0)
-    d = (0, 1, 0)
-
-    # form one 3D configuration
-    conf = np.array([a, b, c, d])
-    assert (conf.shape == (4, 3))
-
-    # make n_samples copies
-    xyz = np.array([conf] * n_samples, dtype=float)
-    assert (xyz.shape == (n_samples, 4, 3))
-
-    # assign y and z coordinates of particle d to unit-circle samples
-    xyz[:, 3, 1:] = _sample_unit_circle(n_samples)
-
-    return xyz
-
+from espaloma.utils.geometry import _sample_four_particle_torsion_scan, _timemachine_signed_torsion_angle
 
 
 def test_dihedral_vectors():
@@ -70,25 +21,6 @@ def test_dihedral_vectors():
         decimal=3,
     )
 
-def _timemachine_signed_torsion_angle(ci, cj, ck, cl):
-    """Reference implementation from Yutong Zhao's timemachine
-
-    Copied directly from
-    https://github.com/proteneer/timemachine/blob/1a0ab45e605dc1e28c44ea90f38cb0dedce5c4db/timemachine/potentials/bonded.py#L152-L199
-    (but with 3 lines of dead code removed, and delta_r inlined)
-    """
-
-    rij = cj - ci
-    rkj = cj - ck
-    rkl = cl - ck
-
-    n1 = np.cross(rij, rkj)
-    n2 = np.cross(rkj, rkl)
-
-    y = np.sum(np.multiply(np.cross(n1, n2), rkj / np.linalg.norm(rkj, axis=-1, keepdims=True)), axis=-1)
-    x = np.sum(np.multiply(n1, n2), -1)
-
-    return np.arctan2(y, x)
 
 def test_dihedral_points():
     n_samples = 1000

--- a/espaloma/mm/tests/test_openmm_consistency.py
+++ b/espaloma/mm/tests/test_openmm_consistency.py
@@ -1,11 +1,16 @@
-import numpy as np
 import numpy.testing as npt
 import pytest
 import torch
-from simtk import openmm, unit
+from simtk import openmm
+from simtk import openmm as mm
+from simtk import unit
+
+angle_unit = unit.radian
+energy_unit = unit.kilojoule_per_mole
+
+from simtk.openmm import app
 
 import espaloma as esp
-from espaloma.units import *
 
 
 @pytest.mark.parametrize(
@@ -84,7 +89,7 @@ def test_energy_angle_and_bond(g):
             getEnergy=True, getParameters=True, groups=2 ** idx,
         )
 
-        energy = state.getPotentialEnergy().value_in_unit(ENERGY_UNIT)
+        energy = state.getPotentialEnergy().value_in_unit(esp.units.ENERGY_UNIT)
 
         energies[name] = energy
 
@@ -111,8 +116,8 @@ def test_energy_angle_and_bond(g):
     # for each atom, store n_snapshots x 3
     g.nodes["n1"].data["xyz"] = torch.tensor(
         simulation.context.getState(getPositions=True)
-        .getPositions(asNumpy=True)
-        .value_in_unit(DISTANCE_UNIT),
+            .getPositions(asNumpy=True)
+            .value_in_unit(esp.units.DISTANCE_UNIT),
         dtype=torch.float32,
     )[None, :, :].permute(1, 0, 2)
 

--- a/espaloma/mm/tests/test_openmm_consistency.py
+++ b/espaloma/mm/tests/test_openmm_consistency.py
@@ -62,13 +62,13 @@ def test_periodic_torsion(periodicity=4, k=-10 * energy_unit, n_samples=100):
     xyz = torch.tensor(xyz_np)
     x0, x1, x2, x3 = xyz[:, 0, :], xyz[:, 1, :], xyz[:, 2, :], xyz[:, 3, :]
     theta = esp.mm.geometry.dihedral(x0, x1, x2, x3).reshape((n_samples, 1))
-    ks = torch.zeros(6)
-    ks[periodicity - 1] = k / esp.units.ENERGY_UNIT
+    ks = torch.zeros(n_samples, 6)
+    ks[:, periodicity - 1] = k / esp.units.ENERGY_UNIT
 
     # TODO: currently failing with run-time tensor index errors in esp.mm.functional.periodic
     espaloma_energies = esp.mm.functional.periodic(theta, ks) * esp.units.ENERGY_UNIT
 
-    np.testing.assert_almost_equal(actual=espaloma_energies.numpy() / energy_unit, desired=openmm_energies)
+    np.testing.assert_almost_equal(actual=espaloma_energies.numpy().flatten() / energy_unit, desired=openmm_energies)
 
 
 @pytest.mark.parametrize(

--- a/espaloma/mm/tests/test_openmm_consistency.py
+++ b/espaloma/mm/tests/test_openmm_consistency.py
@@ -15,6 +15,8 @@ from simtk.openmm import app
 
 import espaloma as esp
 
+decimal_threshold = 4
+
 
 def _create_torsion_sim(
         periodicity: int = 2,
@@ -65,11 +67,10 @@ def test_periodic_torsion(periodicity=4, k=-10 * omm_energy_unit, n_samples=100)
     ks = torch.zeros(n_samples, 6)
     ks[:, periodicity - 1] = k.value_in_unit(esp.units.ENERGY_UNIT)
 
-    espaloma_energies = esp.mm.functional.periodic(theta, ks) * esp.units.ENERGY_UNIT
-    espaloma_energies_in_omm_units = espaloma_energies.numpy().flatten().value_in_unit(omm_energy_unit)
+    espaloma_energies = esp.mm.functional.periodic(theta, ks).numpy().flatten() * esp.units.ENERGY_UNIT
+    espaloma_energies_in_omm_units = espaloma_energies.value_in_unit(omm_energy_unit)
 
-    # currently failing, off by a factor of 0.00038088
-    np.testing.assert_almost_equal(actual=espaloma_energies_in_omm_units, desired=openmm_energies)
+    np.testing.assert_almost_equal(actual=espaloma_energies_in_omm_units, desired=openmm_energies, decimal=decimal_threshold)
 
 
 @pytest.mark.parametrize(

--- a/espaloma/utils/geometry.py
+++ b/espaloma/utils/geometry.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+
+def _sample_unit_circle(n_samples: int = 1) -> np.ndarray:
+    """
+    >>> np.isclose(np.linalg.norm(_sample_unit_circle(1)), 1)
+    True
+
+    """
+    theta = np.random.rand(n_samples) * 2 * np.pi
+    x = np.cos(theta)
+    y = np.sin(theta)
+    xy = np.array([x, y]).T
+    assert (xy.shape == (n_samples, 2))
+    return xy
+
+
+def _sample_four_particle_torsion_scan(n_samples: int = 1) -> np.ndarray:
+    """Generate n_samples random configurations of a 4-particle system abcd where
+    * distances ab, bc, cd are constant,
+    * angles abc, bcd are constant
+    * dihedral angle abcd is uniformly distributed in [0, 2pi]
+
+    Returns
+    -------
+    xyz : np.ndarray, shape = (n_samples, 4, 3)
+
+    Notes
+    -----
+    * Positions of a,b,c are constant, and x-coordinate of d is constant.
+        To be more exacting, could add random displacements and rotations.
+    """
+    a = (-3, -1, 0)
+    b = (-2, 0, 0)
+    c = (-1, 0, 0)
+    d = (0, 1, 0)
+
+    # form one 3D configuration
+    conf = np.array([a, b, c, d])
+    assert (conf.shape == (4, 3))
+
+    # make n_samples copies
+    xyz = np.array([conf] * n_samples, dtype=float)
+    assert (xyz.shape == (n_samples, 4, 3))
+
+    # assign y and z coordinates of particle d to unit-circle samples
+    xyz[:, 3, 1:] = _sample_unit_circle(n_samples)
+
+    return xyz
+
+
+def _timemachine_signed_torsion_angle(ci, cj, ck, cl):
+    """Reference implementation from Yutong Zhao's timemachine
+
+    Copied directly from
+    https://github.com/proteneer/timemachine/blob/1a0ab45e605dc1e28c44ea90f38cb0dedce5c4db/timemachine/potentials/bonded.py#L152-L199
+    (but with 3 lines of dead code removed, and delta_r inlined)
+    """
+
+    rij = cj - ci
+    rkj = cj - ck
+    rkl = cl - ck
+
+    n1 = np.cross(rij, rkj)
+    n2 = np.cross(rkj, rkl)
+
+    y = np.sum(np.multiply(np.cross(n1, n2), rkj / np.linalg.norm(rkj, axis=-1, keepdims=True)), axis=-1)
+    x = np.sum(np.multiply(n1, n2), -1)
+
+    return np.arctan2(y, x)


### PR DESCRIPTION
Attempting to isolate and address possible dihedral geometry issue noticed in https://github.com/choderalab/espaloma/pull/41#issuecomment-708044645 .

- [x] Sample random 4-particle geometries with dihedral angles uniform in [0, 2pi]
- [x] Create 4-particle OpenMM Simulation containing only PeriodicTorsionForce
- [x] Update dihedral geometry computation to match reference implementation
- [x] Assert geometry consistency with timemachine
- [x] Assert energy consistency between `espaloma` and OpenMM on these geometries
- [ ] (optional) Assert force consistency between `espaloma` and OpenMM on these geometries

(Current  test for PeriodicTorsionForce energy consistency with OpenMM asserts energy-sum consistency to [1 decimal place](https://github.com/choderalab/espaloma/blob/d5680ab9768a51c8be515d9263bc5de100083e7b/espaloma/mm/tests/test_openmm_consistency.py#L142), which indicates that the current implementation is close, although it's possible there's a remaining issue.)