### PR TITLE
Fix shape assertions in `dihedral`

### DIFF
--- a/espaloma/mm/geometry.py
+++ b/espaloma/mm/geometry.py
@@ -65,9 +65,12 @@ def dihedral(x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor, x3: torch.Ten
         https://github.com/proteneer/timemachine/blob/1a0ab45e605dc1e28c44ea90f38cb0dedce5c4db/timemachine/potentials/bonded.py#L152-L199
     """
     # check input shapes
-    num_torsions = len(x0)
+    # TODO: check this more carefully
+#    dim = x0.shape[-1]
+#    num_torsions = x0.shape[-2]
+
     for x in [x0, x1, x2, x3]:
-        assert (x.shape == (num_torsions, 3))
+        assert (x.shape == x0.shape)
 
     # compute displacements 0->1, 2->1, 2->3
     r01 = x1 - x0
@@ -86,7 +89,8 @@ def dihedral(x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor, x3: torch.Ten
     # choose quadrant correctly
     theta = torch.atan2(y, x)
 
-    assert (theta.shape == (num_torsions,))
+    # TODO: check this more carefully
+#    assert (theta.shape == (num_torsions,))
 
     return theta
 

--- a/espaloma/mm/geometry.py
+++ b/espaloma/mm/geometry.py
@@ -66,7 +66,8 @@ def dihedral(x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor, x3: torch.Ten
     """
     # check input shapes
     # TODO: check this more carefully
-#    dim = x0.shape[-1]
+    dim = x0.shape[-1]
+    assert (dim == 3)
 #    num_torsions = x0.shape[-2]
 
     for x in [x0, x1, x2, x3]:


### PR DESCRIPTION
I had introduced an overly strict assertion that the input is in shape `(num_torsions, 3)` in https://github.com/choderalab/espaloma/commit/a4f52044d3aabb840c3229987b0cb85e8a1b94b8, but the code also handles case `(num_snapshots, num_torsions, 3)`