### PR TITLE
Fix improper indices

### DIFF
--- a/espaloma/nn/readout/janossy.py
+++ b/espaloma/nn/readout/janossy.py
@@ -231,6 +231,9 @@ class JanossyPoolingImproper(torch.nn.Module):
         )
 
         # pool
+        #   sum over three cyclic permutations of "h0", "h2", "h3", assuming "h1" is the central atom in the improper
+        #   following the smirnoff trefoil convention [(0, 1, 2, 3), (2, 1, 3, 0), (3, 1, 0, 2)]
+        #   https://github.com/openforcefield/openforcefield/blob/166c9864de3455244bd80b2c24656bd7dda3ae2d/openforcefield/typing/engines/smirnoff/parameters.py#L3326-L3360
         for big_idx in self.levels:
 
             g.apply_nodes(
@@ -253,18 +256,18 @@ class JanossyPoolingImproper(torch.nn.Module):
                                     ),
                                     torch.cat(
                                         [
-                                            nodes.data["h0"],
                                             nodes.data["h2"],
-                                            nodes.data["h3"],
                                             nodes.data["h1"],
+                                            nodes.data["h3"],
+                                            nodes.data["h0"],
                                         ],
                                         dim=1
                                     ),
                                     torch.cat(
                                         [
-                                            nodes.data["h0"],
                                             nodes.data["h3"],
                                             nodes.data["h1"],
+                                            nodes.data["h0"],
                                             nodes.data["h2"],
                                         ],
                                         dim=1

--- a/espaloma/redux/symmetry.py
+++ b/espaloma/redux/symmetry.py
@@ -78,8 +78,14 @@ class ValenceModel(nn.Module):
         proper_perms = [(0, 1, 2, 3), (3, 2, 1, 0)]
         propers = symmetry_pool(self.readouts.propers, indices.propers, proper_perms)
 
-        # improper torsions: sum over (abcd, acdb, adbc)
-        improper_perms = [(0, 1, 2, 3), (0, 2, 3, 1), (0, 3, 1, 2)]
+        # improper torsions: sum over 3 cyclic permutations of non-central atoms, following smirnoff trefoil convention
+        #   https://github.com/openforcefield/openforcefield/blob/166c9864de3455244bd80b2c24656bd7dda3ae2d/openforcefield/typing/engines/smirnoff/parameters.py#L3326-L3360
+
+        central = 1
+        others = [0, 2, 3]
+        other_perms = [(0, 1, 2), (1, 2, 0), (2, 0, 1)]
+        improper_perms = [(others[i], central, others[j], others[k]) for (i, j, k) in other_perms]
+
         impropers = symmetry_pool(self.readouts.impropers, indices.impropers, improper_perms)
 
         return ParameterizedSystem(atoms=atoms, bonds=bonds, angles=angles, propers=propers, impropers=impropers)


### PR DESCRIPTION
Trefoil permutations for impropers mistakenly assumed the central atom had tag `:1` in SMARTS match (0 in Python indexing), but it actually has tag `:2` in SMARTS match (1 in Python indexing)

Thanks to @jchodera for spotting this within ~10 milliseconds of being shown the code.