### PR TITLE
Added out feature during pooling in train_all_params.

### DIFF
--- a/espaloma/app/train_all_params.py
+++ b/espaloma/app/train_all_params.py
@@ -43,7 +43,7 @@ def run(args):
     readout = esp.nn.readout.janossy.JanossyPooling(
         in_features=units,
         config=args.janossy_config,
-        out_features={2: ["k", "eq"], 3: ["k", "eq"],},
+        out_features={1: ["k", "eq"], 2: ["k", "eq"], 3: ["k", "eq"]},
     )
 
     net = torch.nn.Sequential(representation, readout)


### PR DESCRIPTION
Hi All,

I'm in the process of going though your paper and code, hoping to reproduce the reported results. I'm currently working through sections 3.1 (repro atom typing) and 3.2 (recover MM parameters) of the paper. If I'm not mistaken, the scripts `espaloma/app/train_multi_typing.py` and `espaloma/app/train_all_params.py` are intended to reproduce sections 3.1 and 3.2 of the paper, respectively, is that correct? In my tests I've only set n_epochs to 5000 as mentioned in the paper and kept everything else as defaults; is there other parameters I need to set to fully reproduce the work?

In running `espaloma/app/train_multi_typing.py` I'm getting accuracies below the 98% reported in the paper using the default data/settings provided. Any ideas on what I should do differently? Results:

<img width="512" alt="Screen Shot 2020-11-05 at 10 16 40 AM" src="https://user-images.githubusercontent.com/1364252/99113548-4f494c00-25a4-11eb-800c-74cb37af155a.png">

Similarly, running `espaloma/app/train_all_params.py` results in the following, where something looks suspicious with r2:

<img width="417" alt="Screen Shot 2020-11-13 at 10 51 38 AM" src="https://user-images.githubusercontent.com/1364252/99113613-6e47de00-25a4-11eb-8bae-ce07078ae88b.png">

Lastly, running `espaloma/app/train_all_params.py` out of the box resulted in a traceback and I had to make the included alteration. Please let me know if this correction seems sensible.

Thanks!