### PR TITLE
Add functionaly for SMIRNOFF convention of permuting atoms for improper calculations

### DIFF
--- a/espaloma/data/dataset.py
+++ b/espaloma/data/dataset.py
@@ -340,7 +340,7 @@ class GraphDataset(Dataset):
             graph.save(path + "/" + str(idx))
 
     @classmethod
-    def load(cls, path):
+    def load(cls, path, improper_def=None):
         import os
 
         paths = os.listdir(path)
@@ -348,6 +348,6 @@ class GraphDataset(Dataset):
 
         graphs = []
         for _path in paths:
-            graphs.append(esp.Graph.load(path + "/" + _path))
+            graphs.append(esp.Graph.load(path + "/" + _path, improper_def))
 
         return cls(graphs)

--- a/espaloma/data/dataset.py
+++ b/espaloma/data/dataset.py
@@ -225,6 +225,19 @@ class Dataset(abc.ABC, torch.utils.data.Dataset):
         with open(path, "wb") as f_handle:
             pickle.dump(self.graphs, f_handle)
 
+    def regenerate_impropers(self, improper_def='smirnoff'):
+        """
+        Regenerate the improper nodes for all graphs.
+
+        Parameters
+        ----------
+        improper_def : str
+            Which convention to use for permuting impropers.
+        """
+        from espaloma.graphs.utils.regenerate_impropers import regenerate_impropers
+        for g in self.graphs:
+            regenerate_impropers(g, improper_def)
+
     @classmethod
     def load(cls, path):
         """Load path to dataset.
@@ -340,7 +353,7 @@ class GraphDataset(Dataset):
             graph.save(path + "/" + str(idx))
 
     @classmethod
-    def load(cls, path, improper_def=None):
+    def load(cls, path):
         import os
 
         paths = os.listdir(path)
@@ -348,6 +361,6 @@ class GraphDataset(Dataset):
 
         graphs = []
         for _path in paths:
-            graphs.append(esp.Graph.load(path + "/" + _path, improper_def))
+            graphs.append(esp.Graph.load(path + "/" + _path))
 
         return cls(graphs)

--- a/espaloma/graphs/graph.py
+++ b/espaloma/graphs/graph.py
@@ -44,7 +44,8 @@ class Graph(BaseGraph):
 
     """
 
-    def __init__(self, mol=None, homograph=None, heterograph=None):
+    def __init__(self, mol=None, homograph=None, heterograph=None,
+        improper_def='smirnoff'):
         # TODO : more pythonic way allow multiple constructors:
         #   Graph.from_smiles(...), Graph.from_mol(...), Graph.from_homograph(...), ...
         #   rather than Graph(mol=None, homograph=None, ...)
@@ -60,7 +61,7 @@ class Graph(BaseGraph):
 
         if homograph is not None and heterograph is None:
             heterograph = self.get_heterograph_from_graph_and_mol(
-                homograph, mol
+                homograph, mol, improper_def
             )
 
         self.mol = mol
@@ -154,14 +155,14 @@ class Graph(BaseGraph):
         return graph
 
     @staticmethod
-    def get_heterograph_from_graph_and_mol(graph, mol):
+    def get_heterograph_from_graph_and_mol(graph, mol, improper_def='smirnoff'):
         import dgl
         assert isinstance(
             graph, dgl.DGLGraph
         ), "graph can only be dgl Graph object."
 
         heterograph = esp.graphs.utils.read_heterogeneous_graph.from_homogeneous_and_mol(
-            graph, mol
+            graph, mol, improper_def
         )
 
         return heterograph

--- a/espaloma/graphs/graph.py
+++ b/espaloma/graphs/graph.py
@@ -98,6 +98,8 @@ class Graph(BaseGraph):
 
         ## Generate new improper torsion permutations
         idxs = improper_torsion_indices(self.mol, improper_def)
+        if len(idxs) == 0:
+            return
 
         ## Add new nodes of type n4_improper (one for each permut)
         g = dgl.add_nodes(g, idxs.shape[0], ntype='n4_improper')
@@ -118,7 +120,7 @@ class Graph(BaseGraph):
         self.heterograph = g
 
     @classmethod
-    def load(cls, path):
+    def load(cls, path, improper_def=None):
         import json
         import dgl
 
@@ -133,7 +135,11 @@ class Graph(BaseGraph):
             mol = Molecule.from_json(mol)
         except:
             mol = Molecule.from_dict(mol)
-        return cls(mol=mol, homograph=homograph, heterograph=heterograph)
+
+        g = cls(mol=mol, homograph=homograph, heterograph=heterograph)
+        if improper_def is not None:
+            g.regenerate_impropers(improper_def)
+        return g
 
     @staticmethod
     def get_homograph_from_mol(mol):

--- a/espaloma/graphs/graph.py
+++ b/espaloma/graphs/graph.py
@@ -117,6 +117,19 @@ class Graph(BaseGraph):
             incoming_etype = ('n1', f'n1_as_{i}_in_n4_improper', 'n4_improper')
             g = dgl.add_edges(g, n1_ids, permut_ids, etype=incoming_etype)
 
+        ## New edges b/n improper permuts and the graph (for global pooling)
+        # edge from improper node to graph
+        outgoing_etype = ('n4_improper', f'n4_improper_in_g', 'g')
+        g = dgl.add_edges(g, permut_ids, np.zeros_like(permut_ids),
+            etype=outgoing_etype)
+
+        # edge from graph to improper nodes
+        incoming_etype = ('g', 'g_has_n4_improper', 'n4_improper')
+        g = dgl.add_edges(g, np.zeros_like(permut_ids), permut_ids,
+            etype=incoming_etype)
+
+        g.nodes['n4_improper'].data['idxs'] = torch.tensor(idxs)
+
         self.heterograph = g
 
     @classmethod

--- a/espaloma/graphs/tests/test_deploy.py
+++ b/espaloma/graphs/tests/test_deploy.py
@@ -62,7 +62,7 @@ def test_energy_consistent_caffeine():
 
     # parametrize caffeine molecule using the parametrization
     ## Should there be a second test for SMIRNOFF impropers?
-    g = esp.Graph("CN1C=NC2=C1C(=O)N(C(=O)N2C)C", improper_def='espaloma')
+    g = esp.Graph("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
     g = ff.parametrize(g)
     system = esp.graphs.deploy.openmm_system_from_graph(g, suffix="_ref")
 

--- a/espaloma/graphs/tests/test_deploy.py
+++ b/espaloma/graphs/tests/test_deploy.py
@@ -61,7 +61,8 @@ def test_energy_consistent_caffeine():
     ff = esp.graphs.legacy_force_field.LegacyForceField("openff-1.2.0")
 
     # parametrize caffeine molecule using the parametrization
-    g = esp.Graph("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+    ## Should there be a second test for SMIRNOFF impropers?
+    g = esp.Graph("CN1C=NC2=C1C(=O)N(C(=O)N2C)C", improper_def='espaloma')
     g = ff.parametrize(g)
     system = esp.graphs.deploy.openmm_system_from_graph(g, suffix="_ref")
 

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -45,7 +45,7 @@ def _all_improper_torsion_indices(offmol: Molecule) -> np.ndarray:
     )
 
 
-def improper_torsion_indices(offmol: Molecule, improper_def='smirnoff') -> np.ndarray:
+def improper_torsion_indices(offmol: Molecule, improper_def='espaloma') -> np.ndarray:
     """ "[*:1]~[X3:2](~[*:3])~[*:4]" matches (_all_improper_torsion_indices returns "[*:1]~[*:2](~[*:3])~[*:4]" matches)
 
     improper_def allows for choosing which atom will be the central atom in the

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -45,7 +45,7 @@ def _all_improper_torsion_indices(offmol: Molecule) -> np.ndarray:
     )
 
 
-def improper_torsion_indices(offmol: Molecule, improper_def='espaloma') -> np.ndarray:
+def improper_torsion_indices(offmol: Molecule, improper_def='smirnoff') -> np.ndarray:
     """ "[*:1]~[X3:2](~[*:3])~[*:4]" matches (_all_improper_torsion_indices returns "[*:1]~[*:2](~[*:3])~[*:4]" matches)
 
     improper_def allows for choosing which atom will be the central atom in the

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -61,37 +61,31 @@ def improper_torsion_indices(offmol: Molecule, improper_def='espaloma') -> np.nd
     Motivation: offmol.impropers returns a large number of impropers, and we may wish to restrict this number.
     May update this filter definition based on discussion in https://github.com/openff.toolkit/openff.toolkit/issues/746
     """
-    ## Check options
-    if (improper_def != 'espaloma') and (improper_def != 'smirnoff'):
-        raise ValueError(f'Unknown value for improper_def: {improper_def}')
 
     ## Find all atoms bound to exactly 3 other atoms
-    ## This finds all orderings, which is what we want for the espaloma case
-    ##  but not for smirnoff
-    improper_smarts = "[*:1]~[X3:2](~[*:3])~[*:4]"
-    mol_idxs = offmol.chemical_environment_matches(improper_smarts)
-
     if improper_def == 'espaloma':
+        ## This finds all orderings, which is what we want for the espaloma case
+        ##  but not for smirnoff
+        improper_smarts = '[*:1]~[X3:2](~[*:3])~[*:4]'
+        mol_idxs = offmol.chemical_environment_matches(improper_smarts)
         return np.array(mol_idxs)
+    elif improper_def == 'smirnoff':
+        improper_smarts = '[*:2]~[X3:1](~[*:3])~[*:4]'
+        ## For smirnoff ordering, we only want to find the unique combinations
+        ##  of atoms forming impropers so we can permute them the way we want
+        mol_idxs = offmol.chemical_environment_matches(improper_smarts,
+            unique=True)
 
-    ## Get all unique improper centers, and the list of atoms that they
-    ##  bind to
-    imp_centers = {}
-    for idxs in mol_idxs:
-        center_atom = idxs[1]
-        if center_atom in imp_centers:
-            continue
-        other_atoms = tuple(sorted([idxs[0]]+list(idxs[2:])))
-        imp_centers[center_atom] = other_atoms
+        ## Get all ccw orderings
+        # feels like there should be some good way to do this with itertools...
+        idx_permuts = []
+        for c, *other_atoms in mol_idxs:
+            for i in range(3):
+                idx = [c]
+                for j in range(3):
+                    idx.append(other_atoms[(i+j)%3])
+                idx_permuts.append(tuple(idx))
 
-    ## Get all ccw orderings
-    # feels like there should be some good way to do this with itertools...
-    mol_idxs = []
-    for c, other_atoms in imp_centers.items():
-        for i in range(3):
-            idx = [c]
-            for j in range(3):
-                idx.append(other_atoms[(i+j)%3])
-            mol_idxs.append(tuple(idx))
-
-    return np.array(mol_idxs)
+        return np.array(idx_permuts)
+    else:
+        raise ValueError(f'Unknown value for improper_def: {improper_def}')

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -45,13 +45,53 @@ def _all_improper_torsion_indices(offmol: Molecule) -> np.ndarray:
     )
 
 
-def improper_torsion_indices(offmol: Molecule) -> np.ndarray:
+def improper_torsion_indices(offmol: Molecule, improper_def='espaloma') -> np.ndarray:
     """ "[*:1]~[X3:2](~[*:3])~[*:4]" matches (_all_improper_torsion_indices returns "[*:1]~[*:2](~[*:3])~[*:4]" matches)
+
+    improper_def allows for choosing which atom will be the central atom in the
+    permutations:
+    smirnoff: central atom is listed first
+    espaloma: central atom is listed second
+
+    Addtionally, for smirnoff, only take the subset of atoms that corresponds
+    to the ccw traversal of connected atoms.
 
     Notes
     -----
     Motivation: offmol.impropers returns a large number of impropers, and we may wish to restrict this number.
     May update this filter definition based on discussion in https://github.com/openff.toolkit/openff.toolkit/issues/746
     """
+    ## Check options
+    if (improper_def != 'espaloma') and (improper_def != 'smirnoff'):
+        raise ValueError(f'Unknown value for improper_def: {improper_def}')
+
+    ## Find all atoms bound to exactly 3 other atoms
+    ## This finds all orderings, which is what we want for the espaloma case
+    ##  but not for smirnoff
     improper_smarts = "[*:1]~[X3:2](~[*:3])~[*:4]"
-    return np.array(offmol.chemical_environment_matches(improper_smarts))
+    mol_idxs = offmol.chemical_environment_matches(improper_smarts)
+
+    if improper_def == 'espaloma':
+        return np.array(mol_idxs)
+
+    ## Get all unique improper centers, and the list of atoms that they
+    ##  bind to
+    imp_centers = {}
+    for idxs in mol_idxs:
+        center_atom = idxs[1]
+        if center_atom in imp_centers:
+            continue
+        other_atoms = tuple(sorted([idxs[0]]+list(idxs[2:])))
+        imp_centers[center_atom] = other_atoms
+
+    ## Get all ccw orderings
+    # feels like there should be some good way to do this with itertools...
+    mol_idxs = []
+    for c, other_atoms in imp_centers.items():
+        for i in range(3):
+            idx = [c]
+            for j in range(3):
+                idx.append(other_atoms[(i+j)%3])
+            mol_idxs.append(tuple(idx))
+
+    return np.array(mol_idxs)

--- a/espaloma/graphs/utils/read_heterogeneous_graph.py
+++ b/espaloma/graphs/utils/read_heterogeneous_graph.py
@@ -31,7 +31,7 @@ def duplicate_index_ordering(indices: np.ndarray) -> np.ndarray:
 
 
 def relationship_indices_from_offmol(
-    offmol: Molecule,
+    offmol: Molecule, improper_def='smirnoff'
 ) -> Dict[str, torch.Tensor]:
     """Construct a dictionary that maps node names (like "n2") to torch tensors of indices
 
@@ -44,7 +44,8 @@ def relationship_indices_from_offmol(
     idxs["n2"] = offmol_indices.bond_indices(offmol)
     idxs["n3"] = offmol_indices.angle_indices(offmol)
     idxs["n4"] = offmol_indices.proper_torsion_indices(offmol)
-    idxs["n4_improper"] = offmol_indices.improper_torsion_indices(offmol)
+    idxs["n4_improper"] = offmol_indices.improper_torsion_indices(offmol,
+        improper_def)
 
     if len(idxs["n4"]) == 0:
         idxs["n4"] = np.empty((0, 4))
@@ -67,7 +68,7 @@ def relationship_indices_from_offmol(
     return idxs
 
 
-def from_homogeneous_and_mol(g, offmol):
+def from_homogeneous_and_mol(g, offmol, improper_def='smirnoff'):
     r"""Build heterogeneous graph from homogeneous ones.
 
 
@@ -97,7 +98,7 @@ def from_homogeneous_and_mol(g, offmol):
     a = g.adjacency_matrix()
 
     # get all the indices
-    idxs = relationship_indices_from_offmol(offmol)
+    idxs = relationship_indices_from_offmol(offmol, improper_def)
 
     # make them all numpy
     idxs = {key: value.numpy() for key, value in idxs.items()}

--- a/espaloma/graphs/utils/read_heterogeneous_graph.py
+++ b/espaloma/graphs/utils/read_heterogeneous_graph.py
@@ -31,7 +31,7 @@ def duplicate_index_ordering(indices: np.ndarray) -> np.ndarray:
 
 
 def relationship_indices_from_offmol(
-    offmol: Molecule, improper_def='smirnoff'
+    offmol: Molecule
 ) -> Dict[str, torch.Tensor]:
     """Construct a dictionary that maps node names (like "n2") to torch tensors of indices
 
@@ -44,8 +44,7 @@ def relationship_indices_from_offmol(
     idxs["n2"] = offmol_indices.bond_indices(offmol)
     idxs["n3"] = offmol_indices.angle_indices(offmol)
     idxs["n4"] = offmol_indices.proper_torsion_indices(offmol)
-    idxs["n4_improper"] = offmol_indices.improper_torsion_indices(offmol,
-        improper_def)
+    idxs["n4_improper"] = offmol_indices.improper_torsion_indices(offmol)
 
     if len(idxs["n4"]) == 0:
         idxs["n4"] = np.empty((0, 4))
@@ -68,7 +67,7 @@ def relationship_indices_from_offmol(
     return idxs
 
 
-def from_homogeneous_and_mol(g, offmol, improper_def='smirnoff'):
+def from_homogeneous_and_mol(g, offmol):
     r"""Build heterogeneous graph from homogeneous ones.
 
 
@@ -98,7 +97,7 @@ def from_homogeneous_and_mol(g, offmol, improper_def='smirnoff'):
     a = g.adjacency_matrix()
 
     # get all the indices
-    idxs = relationship_indices_from_offmol(offmol, improper_def)
+    idxs = relationship_indices_from_offmol(offmol)
 
     # make them all numpy
     idxs = {key: value.numpy() for key, value in idxs.items()}

--- a/espaloma/graphs/utils/regenerate_impropers.py
+++ b/espaloma/graphs/utils/regenerate_impropers.py
@@ -1,0 +1,57 @@
+import dgl
+import numpy as np
+import torch
+
+from .offmol_indices import improper_torsion_indices
+from ..graph import Graph
+
+def regenerate_impropers(g: Graph, improper_def='smirnoff'):
+        """
+        Method to regenerate the improper nodes according to the specified
+        method of permuting the impropers. Modifies the esp.Graph's heterograph
+        in place and returns the new heterograph.
+        NOTE: This will clear the data on all n4_improper nodes, including
+        previously generated improper from JanossyPoolingImproper.
+        """
+
+        ## First get rid of the old nodes/edges
+        hg = g.heterograph
+        hg = dgl.remove_nodes(hg, hg.nodes('n4_improper'), 'n4_improper')
+
+        ## Generate new improper torsion permutations
+        idxs = improper_torsion_indices(g.mol, improper_def)
+        if len(idxs) == 0:
+            return hg
+
+        ## Add new nodes of type n4_improper (one for each permut)
+        hg = dgl.add_nodes(hg, idxs.shape[0], ntype='n4_improper')
+
+        ## New edges b/n improper permuts and n1 nodes
+        permut_ids = np.arange(idxs.shape[0])
+        for i in range(4):
+            n1_ids = idxs[:,i]
+
+            # edge from improper node to n1 node
+            outgoing_etype = ('n4_improper', f'n4_improper_has_{i}_n1', 'n1')
+            hg = dgl.add_edges(hg, permut_ids, n1_ids, etype=outgoing_etype)
+
+            # edge from n1 to improper
+            incoming_etype = ('n1', f'n1_as_{i}_in_n4_improper', 'n4_improper')
+            hg = dgl.add_edges(hg, n1_ids, permut_ids, etype=incoming_etype)
+
+        ## New edges b/n improper permuts and the graph (for global pooling)
+        # edge from improper node to graph
+        outgoing_etype = ('n4_improper', f'n4_improper_in_g', 'g')
+        hg = dgl.add_edges(hg, permut_ids, np.zeros_like(permut_ids),
+            etype=outgoing_etype)
+
+        # edge from graph to improper nodes
+        incoming_etype = ('g', 'g_has_n4_improper', 'n4_improper')
+        hg = dgl.add_edges(hg, np.zeros_like(permut_ids), permut_ids,
+            etype=incoming_etype)
+
+        hg.nodes['n4_improper'].data['idxs'] = torch.tensor(idxs)
+
+        g.heterograph = hg
+
+        return hg

--- a/espaloma/mm/tests/test_geometry.py
+++ b/espaloma/mm/tests/test_geometry.py
@@ -11,29 +11,39 @@ def test_import():
 # later, if we want to do multiple molecules, group these into a struct
 smiles = "c1ccccc1"
 n_samples = 2
-expected_n_terms = dict(n2=24, n3=36, n4=48, n4_improper=36)
-
+## Different number of expected terms for different improper permutations
+expected_n_terms = {
+    'espaloma': dict(n2=24, n3=36, n4=48, n4_improper=36),
+    'smirnoff': dict(n2=24, n3=36, n4=48, n4_improper=18)
+}
 
 @pytest.fixture
-def g():
-    g = esp.Graph(smiles)
+def all_g():
     from espaloma.data.md import MoleculeVacuumSimulation
 
-    simulation = MoleculeVacuumSimulation(
-        n_samples=n_samples, n_steps_per_sample=1
-    )
-    g = simulation.run(g, in_place=True)
-    return g
+    all_g = {}
+    for improper_def in ('espaloma', 'smirnoff'):
+        g = esp.Graph(smiles, improper_def=improper_def)
 
-
-def test_geometry_can_be_computed_without_exceptions(g):
-    g = esp.mm.geometry.geometry_in_graph(g.heterograph)
-
-
-def test_geometry_n_terms(g):
-    g = esp.mm.geometry.geometry_in_graph(g.heterograph)
-
-    for term in ["n2", "n3", "n4", "n4_improper"]:
-        assert g.nodes[term].data["x"].shape == torch.Size(
-            [expected_n_terms[term], n_samples]
+        simulation = MoleculeVacuumSimulation(
+            n_samples=n_samples, n_steps_per_sample=1
         )
+        g = simulation.run(g, in_place=True)
+        all_g[improper_def] = g
+    return all_g
+
+
+def test_geometry_can_be_computed_without_exceptions(all_g):
+    for g in all_g.values():
+        g = esp.mm.geometry.geometry_in_graph(g.heterograph)
+
+
+def test_geometry_n_terms(all_g):
+    for improper_def, g in all_g.items():
+        g = esp.mm.geometry.geometry_in_graph(g.heterograph)
+
+        for term, n_terms in expected_n_terms[improper_def].items():
+            assert g.nodes[term].data["x"].shape == torch.Size(
+                [n_terms, n_samples]
+            )
+

--- a/espaloma/mm/tests/test_geometry.py
+++ b/espaloma/mm/tests/test_geometry.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import espaloma as esp
-
+from espaloma.graphs.utils.regenerate_impropers import regenerate_impropers
 
 def test_import():
     esp.mm.geometry
@@ -13,6 +13,7 @@ smiles = "c1ccccc1"
 n_samples = 2
 ## Different number of expected terms for different improper permutations
 expected_n_terms = {
+    'none': dict(n2=24, n3=36, n4=48, n4_improper=36),
     'espaloma': dict(n2=24, n3=36, n4=48, n4_improper=36),
     'smirnoff': dict(n2=24, n3=36, n4=48, n4_improper=18)
 }
@@ -22,8 +23,10 @@ def all_g():
     from espaloma.data.md import MoleculeVacuumSimulation
 
     all_g = {}
-    for improper_def in ('espaloma', 'smirnoff'):
-        g = esp.Graph(smiles, improper_def=improper_def)
+    for improper_def in expected_n_terms.keys():
+        g = esp.Graph(smiles)
+        if improper_def != 'none':
+            regenerate_impropers(g, improper_def)
 
         simulation = MoleculeVacuumSimulation(
             n_samples=n_samples, n_steps_per_sample=1


### PR DESCRIPTION
Added functionality to use SMIRNOFF convention for impropers instead of the current espaloma convention. Current default options will use the SMIRNOFF convention for newly created molecules. When datasets are loaded, no changes will be made if using the default options, however if an argument for `improper_def` is provided, the `n4_improper` nodes will be regenerated according to the provided input.

Resolves #101.