### PR TITLE
Formal charge fix

### DIFF
--- a/espaloma/graphs/tests/test_graph.py
+++ b/espaloma/graphs/tests/test_graph.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 
 def test_graph():
@@ -20,6 +21,18 @@ def test_ndata_consistency(graph):
     import torch
 
     assert torch.equal(graph.ndata["h0"], graph.nodes["n1"].data["h0"])
+
+
+@pytest.mark.parametrize("molecule, charge", [
+    pytest.param("C", 0, id="methane"),
+    pytest.param("[NH4+]", 1, id="Ammonium"),
+    pytest.param("CC(=O)[O-]", -1, id="Acetate")
+])
+def test_formal_charge(molecule, charge):
+    import espaloma as esp
+
+    graph = esp.Graph(molecule)
+    assert torch.sum(graph.nodes["n1"].data["q_ref"]) == charge
 
 
 def test_save_and_load(graph):

--- a/espaloma/graphs/tests/test_graph.py
+++ b/espaloma/graphs/tests/test_graph.py
@@ -32,7 +32,7 @@ def test_formal_charge(molecule, charge):
     import espaloma as esp
 
     graph = esp.Graph(molecule)
-    assert torch.sum(graph.nodes["n1"].data["q_ref"]) == charge
+    assert graph.nodes["g"].data["sum_q"].numpy()[0] == charge
 
 
 def test_save_and_load(graph):

--- a/espaloma/graphs/utils/read_heterogeneous_graph.py
+++ b/espaloma/graphs/utils/read_heterogeneous_graph.py
@@ -272,7 +272,7 @@ def from_homogeneous_and_mol(g, offmol):
     hg = dgl.heterograph({key: list(value) for key, value in hg.items()})
 
     hg.nodes["n1"].data["h0"] = g.ndata["h0"]
-    hg.nodes["g"].data["sum_q"] = torch.Tensor(g.ndata["sum_q"][0])
+    hg.nodes["g"].data["sum_q"] = g.ndata["sum_q"][0].reshape(1, 1)
     # include indices in the nodes themselves
     for term in ["n1", "n2", "n3", "n4", "n4_improper", "onefour", "nonbonded"]:
         hg.nodes[term].data["idxs"] = torch.tensor(idxs[term])

--- a/espaloma/graphs/utils/read_heterogeneous_graph.py
+++ b/espaloma/graphs/utils/read_heterogeneous_graph.py
@@ -272,7 +272,7 @@ def from_homogeneous_and_mol(g, offmol):
     hg = dgl.heterograph({key: list(value) for key, value in hg.items()})
 
     hg.nodes["n1"].data["h0"] = g.ndata["h0"]
-
+    hg.nodes["n1"].data["q_ref"] = g.ndata["formal_charge"]
     # include indices in the nodes themselves
     for term in ["n1", "n2", "n3", "n4", "n4_improper", "onefour", "nonbonded"]:
         hg.nodes[term].data["idxs"] = torch.tensor(idxs[term])

--- a/espaloma/graphs/utils/read_heterogeneous_graph.py
+++ b/espaloma/graphs/utils/read_heterogeneous_graph.py
@@ -272,7 +272,7 @@ def from_homogeneous_and_mol(g, offmol):
     hg = dgl.heterograph({key: list(value) for key, value in hg.items()})
 
     hg.nodes["n1"].data["h0"] = g.ndata["h0"]
-    hg.nodes["n1"].data["q_ref"] = g.ndata["formal_charge"]
+    hg.nodes["g"].data["sum_q"] = torch.Tensor(g.ndata["sum_q"][0])
     # include indices in the nodes themselves
     for term in ["n1", "n2", "n3", "n4", "n4_improper", "onefour", "nonbonded"]:
         hg.nodes[term].data["idxs"] = torch.tensor(idxs[term])

--- a/espaloma/graphs/utils/read_homogeneous_graph.py
+++ b/espaloma/graphs/utils/read_homogeneous_graph.py
@@ -118,6 +118,7 @@ def fp_rdkit(atom):
 # =============================================================================
 def from_openff_toolkit_mol(mol, use_fp=True):
     import dgl
+    from openmm import unit
     # initialize graph
     from rdkit import Chem
 
@@ -130,7 +131,9 @@ def from_openff_toolkit_mol(mol, use_fp=True):
     g.ndata["type"] = torch.Tensor(
         [[atom.atomic_number] for atom in mol.atoms]
     )
-
+    g.ndata["formal_charge"] = torch.Tensor(
+        [[atom.formal_charge.value_in_unit(unit.elementary_charge)] for atom in mol.atoms]
+    )
     h_v = torch.zeros(
         g.ndata["type"].shape[0], 100, dtype=torch.get_default_dtype()
     )
@@ -166,7 +169,7 @@ def from_openff_toolkit_mol(mol, use_fp=True):
 
 def from_oemol(mol, use_fp=True):
     from openeye import oechem
-
+    import dgl
     # initialize graph
     g = dgl.DGLGraph()
 
@@ -176,7 +179,9 @@ def from_oemol(mol, use_fp=True):
     g.ndata["type"] = torch.Tensor(
         [[atom.GetAtomicNum()] for atom in mol.GetAtoms()]
     )
-
+    g.ndata["formal_charge"] = torch.Tensor(
+        [[atom.GetFormalCharge()] for atom in mol.GetAtoms()]
+    )
     h_v = torch.zeros(g.ndata["type"].shape[0], 100, dtype=torch.float32)
 
     h_v[
@@ -219,7 +224,9 @@ def from_rdkit_mol(mol, use_fp=True):
     g.ndata["type"] = torch.Tensor(
         [[atom.GetAtomicNum()] for atom in mol.GetAtoms()]
     )
-
+    g.ndata["formal_charge"] = torch.Tensor(
+        [[atom.GetFormalCharge()] for atom in mol.GetAtoms()]
+    )
     h_v = torch.zeros(g.ndata["type"].shape[0], 100, dtype=torch.float32)
 
     h_v[

--- a/espaloma/graphs/utils/read_homogeneous_graph.py
+++ b/espaloma/graphs/utils/read_homogeneous_graph.py
@@ -131,8 +131,9 @@ def from_openff_toolkit_mol(mol, use_fp=True):
     g.ndata["type"] = torch.Tensor(
         [[atom.atomic_number] for atom in mol.atoms]
     )
-    g.ndata["formal_charge"] = torch.Tensor(
-        [[atom.formal_charge.value_in_unit(unit.elementary_charge)] for atom in mol.atoms]
+    total_charge = mol.total_charge.value_in_unit(unit.elementary_charge)
+    g.ndata["sum_q"] = torch.Tensor(
+        [[total_charge] for _ in range(mol.n_atoms)]
     )
     h_v = torch.zeros(
         g.ndata["type"].shape[0], 100, dtype=torch.get_default_dtype()

--- a/espaloma/nn/readout/charge_equilibrium.py
+++ b/espaloma/nn/readout/charge_equilibrium.py
@@ -75,22 +75,23 @@ class ChargeEquilibrium(torch.nn.Module):
             ntype="n1",
         )
 
-        if "q_ref" in g.nodes["n1"].data:
-            # get total charge
-            g.update_all(
-                dgl.function.copy_src(src="q_ref", out="m_q"),
-                dgl.function.sum(msg="m_q", out="sum_q"),
-                etype="n1_in_g",
-            )
-        else:
-            g.nodes["g"].data["sum_q"] = (
-                torch.ones(
-                    g.batch_size,
-                    1,
-                    device=g.nodes["n1"].data["s"].device,
+        if "sum_q" not in g.nodes["g"].data:
+            if "q_ref" in g.nodes["n1"].data:
+                # get total charge
+                g.update_all(
+                    dgl.function.copy_src(src="q_ref", out="m_q"),
+                    dgl.function.sum(msg="m_q", out="sum_q"),
+                    etype="n1_in_g",
                 )
-                * total_charge
-            )
+            else:
+                g.nodes["g"].data["sum_q"] = (
+                    torch.ones(
+                        g.batch_size,
+                        1,
+                        device=g.nodes["n1"].data["s"].device,
+                    )
+                    * total_charge
+                )
 
         g.update_all(
             dgl.function.copy_src(src="sum_q", out="m_sum_q"),


### PR DESCRIPTION
Fixes #121 by adding the formal charges of the atoms as a reference that can be used during the charge equilibration model. 

Also added tests to ensure the reference charge is correct. 