### PR TITLE
[Bug Fix] Cannot properly update forces when nonbonded interactions are subtracted from graph nodes

### DIFF
--- a/espaloma/data/md.py
+++ b/espaloma/data/md.py
@@ -332,7 +332,7 @@ def subtract_coulomb_force(
         ntype="g",
     )
 
-    if "u_ref_prime" in g.nodes["n1"]:
+    if "u_ref_prime" in g.nodes["n1"].data:
         g.heterograph.apply_nodes(
             lambda node: {
                 "u_ref_prime": node.data["u_ref_prime"] - delta_derivatives
@@ -491,7 +491,7 @@ def subtract_nonbonded_force(
         ntype="g",
     )
 
-    if "u_ref_prime" in g.nodes["n1"]:
+    if "u_ref_prime" in g.nodes["n1"].data:
         g.heterograph.apply_nodes(
             lambda node: {
                 "u_ref_prime": node.data["u_ref_prime"] - derivatives


### PR DESCRIPTION
### Problem
The forces were not properly updated when nonbonded interactions where subtracted from the graph nodes. 
_if statement_ in `espaloma/data/md.py` was not properly defined.


**_before_**
>if "u_ref_prime" in g.nodes["n1"]:

**_after_**
>if "u_ref_prime" in g.nodes["n1"].data:

### Jupyter notebook to reproduce the problem
[test.zip](https://github.com/choderalab/espaloma/files/9737683/test.zip)
