### PR TITLE
Changed default charge method to nn.

### DIFF
--- a/espaloma/graphs/deploy.py
+++ b/espaloma/graphs/deploy.py
@@ -42,7 +42,7 @@ def openmm_system_from_graph(
     g,
     forcefield="openff_unconstrained-1.2.0",
     suffix="",
-    charge_method="am1-bcc",
+    charge_method="nn",
     create_system_kwargs={},
 ):
     """Construct an openmm system from `espaloma.Graph`.


### PR DESCRIPTION
This pull request is to fix issue #141. 

The charge method default was set to 'am1-bcc' rather than 'nn'. This has been changed in this PR. 