### PR TITLE
Fix data split

### DIFF
--- a/espaloma/data/dataset.py
+++ b/espaloma/data/dataset.py
@@ -186,10 +186,14 @@ class Dataset(abc.ABC, torch.utils.data.Dataset):
 
         """
         n_data = len(self)
-        partition = [int(n_data * x / sum(partition)) for x in partition]
+        p_sizes = []
+        for i, _partition in enumerate(partition):
+            p_size = int((n_data - sum(p_sizes)) * _partition / sum(partition[i:]))
+            p_sizes.append(p_size)
+        assert sum(p_sizes) == n_data, f"{p_sizes}, {sum(p_sizes)}"
         ds = []
         idx = 0
-        for p_size in partition:
+        for p_size in p_sizes:
             ds.append(self[idx : idx + p_size])
             idx += p_size
 

--- a/espaloma/nn/sequential.py
+++ b/espaloma/nn/sequential.py
@@ -81,7 +81,7 @@ class Sequential(torch.nn.Module):
         A sequence of numbers (for units) and strings (for activation functions)
         denoting the configuration of the sequential model.
 
-    feature_units : int(default=117)
+    feature_units : int(default=114)
         The number of input channels.
 
     Methods


### PR DESCRIPTION
This PR fixes #150 and #149 


```python
import espaloma as esp

RANDOM_SEED = 1234
path = "../../../exploring-rna/refit-espaloma/openff-default/02-train/merge-data/openff-2.0.0_filtered/pepconf-dlc"
ds = esp.data.dataset.GraphDataset.load(path).shuffle(RANDOM_SEED)
ds_tr, ds_vl, ds_te = ds.split([0.8, 0.1, 0.1])
print(len(ds), len(ds_tr), len(ds_vl), len(ds_te))

>>557 445 56 56
```