### PR TITLE
Support for modern openff-toolkit versions (>=0.11)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -69,14 +69,6 @@ jobs:
           conda list
           mamba --version
 
-      - name: Decrypt and check OE license
-        shell: bash -l {0}
-        env:
-          OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
-        run: |
-          echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
-          python -c "import openeye; assert openeye.OEChemIsLicensed()"
-
       - name: Install package
         shell: bash -l {0}
         run: |

--- a/devtools/conda-envs/espaloma.yaml
+++ b/devtools/conda-envs/espaloma.yaml
@@ -14,7 +14,7 @@ dependencies:
   - numpy
   - matplotlib
   - scipy
-  - openff-toolkit <0.11
+  - openff-toolkit >=0.12
   - openff-forcefields
   - openff-units
   - smirnoff99Frosst

--- a/devtools/conda-envs/espaloma.yaml
+++ b/devtools/conda-envs/espaloma.yaml
@@ -1,10 +1,8 @@
-name: test
+name: espaloma-test
 channels:
   - conda-forge
   - dglteam
   - openeye
-  - defaults
-  - anaconda
 dependencies:
   # Base dependencies
   - python
@@ -27,6 +25,8 @@ dependencies:
   # Testing
   - pytest
   - pytest-cov
+  - pytest-xdist
+  - pytest-randomly
   - codecov
   - nose
   - nose-timer

--- a/espaloma/data/md.py
+++ b/espaloma/data/md.py
@@ -797,7 +797,7 @@ class MoleculeVacuumSimulation(object):
         samples = []
         for idx in range(true_n_conformers):
             # put conformer in simulation
-            simulation.context.setPositions(g.mol.conformers[idx])
+            simulation.context.setPositions(g.mol.conformers[idx].to_openmm())
 
             # set velocities
             simulation.context.setVelocitiesToTemperature(self.temperature)
@@ -825,7 +825,7 @@ class MoleculeVacuumSimulation(object):
             import random
 
             idx = random.choice(list(range(true_n_conformers)))
-            simulation.context.setPositions(g.mol.conformers[idx])
+            simulation.context.setPositions(g.mol.conformers[idx].to_openmm())
 
             # set velocities
             simulation.context.setVelocitiesToTemperature(self.temperature)

--- a/espaloma/graphs/tests/test_deploy.py
+++ b/espaloma/graphs/tests/test_deploy.py
@@ -41,7 +41,7 @@ def test_parameter_consistent_caffeine():
             for _idx in range(force.getNumBonds()):
                 start, end, eq, k_openmm = force.getBondParameters(_idx)
 
-                k_openff = openff_forces["Bonds"][(start, end)].k
+                k_openff = openff_forces["Bonds"][(start, end)].k.to_openmm()
 
                 npt.assert_almost_equal(
                     k_openmm / k_openff,

--- a/espaloma/graphs/utils/read_homogeneous_graph.py
+++ b/espaloma/graphs/utils/read_homogeneous_graph.py
@@ -118,7 +118,6 @@ def fp_rdkit(atom):
 # =============================================================================
 def from_openff_toolkit_mol(mol, use_fp=True):
     import dgl
-    from openmm import unit
 
     # initialize graph
     g = dgl.DGLGraph()
@@ -129,7 +128,7 @@ def from_openff_toolkit_mol(mol, use_fp=True):
     g.ndata["type"] = torch.Tensor(
         [[atom.atomic_number] for atom in mol.atoms]
     )
-    total_charge = mol.total_charge.value_in_unit(unit.elementary_charge)
+    total_charge = mol.total_charge.magnitude
     g.ndata["sum_q"] = torch.Tensor(
         [[total_charge] for _ in range(mol.n_atoms)]
     )

--- a/espaloma/graphs/utils/read_homogeneous_graph.py
+++ b/espaloma/graphs/utils/read_homogeneous_graph.py
@@ -121,9 +121,6 @@ def from_openff_toolkit_mol(mol, use_fp=True):
     from openmm import unit
 
     # initialize graph
-    from rdkit import Chem
-
-    # initialize graph
     g = dgl.DGLGraph()
 
     # enter nodes
@@ -170,7 +167,6 @@ def from_openff_toolkit_mol(mol, use_fp=True):
 
 
 def from_oemol(mol, use_fp=True):
-    from openeye import oechem
     import dgl
 
     # initialize graph
@@ -216,7 +212,6 @@ def from_oemol(mol, use_fp=True):
 
 def from_rdkit_mol(mol, use_fp=True):
     import dgl
-    from rdkit import Chem
 
     # initialize graph
     g = dgl.DGLGraph()

--- a/espaloma/mm/tests/test_charge_energy_consistency.py
+++ b/espaloma/mm/tests/test_charge_energy_consistency.py
@@ -18,7 +18,8 @@ def test_coulomb_energy_consistency(g):
 
 
     """
-    # make simulation
+    from openff.units import unit as openff_unit
+
     from espaloma.data.md import MoleculeVacuumSimulation
 
     print(g.mol)
@@ -32,7 +33,7 @@ def test_coulomb_energy_consistency(g):
     )
 
     simulation = esp_simulation.simulation_from_graph(g)
-    charges = g.mol.partial_charges.flatten()
+    charges = g.mol.partial_charges.m_as(openff_unit.elementary_charge).flatten()
     system = simulation.system
 
     esp_simulation.run(g, in_place=True)


### PR DESCRIPTION
Support for newer and modern versions of `openff-toolkit` is accomplished by using the `openff-units` quantities in `Molecule` objects instead of `openmm.unit`.
