### PR TITLE
update default openff when creating system from graph (fix #160)

### DIFF
--- a/espaloma/graphs/deploy.py
+++ b/espaloma/graphs/deploy.py
@@ -29,7 +29,7 @@ OPENMM_ANGLE_K_UNIT = OPENMM_ENERGY_UNIT / (OPENMM_ANGLE_UNIT**2)
 # =============================================================================
 
 
-def load_forcefield(forcefield="openff_unconstrained-1.2.0"):
+def load_forcefield(forcefield="openff_unconstrained-2.0.0"):
     # get a forcefield
     try:
         ff = ForceField("%s.offxml" % forcefield)
@@ -40,7 +40,7 @@ def load_forcefield(forcefield="openff_unconstrained-1.2.0"):
 
 def openmm_system_from_graph(
     g,
-    forcefield="openff_unconstrained-1.2.0",
+    forcefield="openff_unconstrained-2.0.0",
     suffix="",
     charge_method="am1-bcc",
     create_system_kwargs={},


### PR DESCRIPTION
This PR fixes #160. The default open force field used to create the system was updated to `openff_unconstrained-2.0.0`. Note that this is not the latest openff version (latest is openff-2.1.0). Openff-2.0.0 was chosen to be compatible with the `espaloma-0.3.0` force field which was trained based on `openff-2.0.0`.