### PR TITLE
using `dgl.to_homogeneous` instead of the old deprecated name.

### DIFF
--- a/espaloma/nn/sequential.py
+++ b/espaloma/nn/sequential.py
@@ -135,7 +135,7 @@ class Sequential(torch.nn.Module):
         import dgl
 
         # get homogeneous subgraph
-        g_ = dgl.to_homo(g.edge_type_subgraph(["n1_neighbors_n1"]))
+        g_ = dgl.to_homogeneous(g.edge_type_subgraph(["n1_neighbors_n1"]))
 
         if x is None:
             # get node attributes


### PR DESCRIPTION
DGL method is now named `to_homogeneous`. 

This should fix tests breaking on downstream packages, such as in https://github.com/openmm/openmmforcefields/actions/runs/5555278333/jobs/10146203523?pr=289#step:9:1959