### PR TITLE
Instructions on loading local model

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ espaloma_model(molecule_graph.heterograph)
 openmm_system = esp.graphs.deploy.openmm_system_from_graph(molecule_graph)
 ```
 
+If using espaloma from a local `.pt` file, say for example `espaloma-0.3.1.pt`,
+then you would need to run the `eval` method of the model to get the correct
+inference/predictions, as follows:
+
+```python
+import torch
+...
+# load local pretrained model
+espaloma_model = torch.load("espaloma-0.3.1.pt")
+espaloma_model.eval()
+...
+```
+
+The rest of the code should be the same as in the previous code block example.
+
 # Using espaloma to parameterize small molecules in relative free energy calculations
 
 An example of using espaloma to parameterize small molecules in relative alchemical free energy calculations is provided in the `scripts/perses-benchmark/` directory.

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -24,3 +24,12 @@ systems in a few lines::
     # create an OpenMM System for the specified molecule
     openmm_system = esp.graphs.deploy.openmm_system_from_graph(molecule_graph)
 
+If using espaloma from a local ``.pt`` file, say for example ``espaloma-0.3.1.pt``,
+then you would need to run the ``eval`` method of the model to get the correct
+inference/predictions, as follows:
+
+    # load local pretrained model
+    espaloma_model = torch.load("espaloma-0.3.1.pt")
+    espaloma_model.eval()
+
+The rest of the code should be the same as in the previous example.

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -26,7 +26,7 @@ systems in a few lines::
 
 If using espaloma from a local ``.pt`` file, say for example ``espaloma-0.3.1.pt``,
 then you would need to run the ``eval`` method of the model to get the correct
-inference/predictions, as follows:
+inference/predictions, as follows::
 
     # load local pretrained model
     espaloma_model = torch.load("espaloma-0.3.1.pt")


### PR DESCRIPTION
Add instructions in the deployment section when loading a local model from a serialized `.pt` file. When using it for inference it needs to run the `.eval` method to set the model to evaluation mode, before doing predictions.

Resolves #182 