### PR TITLE
Mmff94 legacy typing with rdkit

### DIFF
--- a/espaloma/data/get_properties.py
+++ b/espaloma/data/get_properties.py
@@ -1,0 +1,32 @@
+import io
+import logging
+import os
+import sys
+import time
+from contextlib import redirect_stdout
+from io import StringIO  # Python 3
+from multiprocessing import Process
+
+import rdkit.Chem.rdForceFieldHelpers as ff
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+if __name__ == '__main__':
+    smile = sys.argv[1]
+    m = Chem.MolFromSmiles(smile)
+
+    m2 = Chem.AddHs(m)
+    AllChem.EmbedMolecule(m2)
+    AllChem.MMFFOptimizeMolecule(m2)
+    pr = ff.MMFFGetMoleculeProperties(m2)
+
+    pr.SetMMFFAngleTerm(False)
+    pr.SetMMFFBondTerm(False)
+    pr.SetMMFFOopTerm(False)
+    pr.SetMMFFStretchBendTerm(False)
+    pr.SetMMFFTorsionTerm(False)
+
+    pr.SetMMFFVerbosity(2)
+
+    mmff = ff.MMFFGetMoleculeForceField(m2,pr)
+    print(mmff.CalcEnergy())

--- a/espaloma/data/rdkit_utils.py
+++ b/espaloma/data/rdkit_utils.py
@@ -1,0 +1,168 @@
+import io
+import logging
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from contextlib import redirect_stdout
+from io import StringIO  # Python 3
+from multiprocessing import Process
+from typing import Dict, List
+
+import rdkit
+import rdkit.Chem.rdForceFieldHelpers as ff
+from openmm import unit
+from rdkit import Chem
+from rdkit.Chem import AllChem
+from rdkit.Chem.rdchem import Mol
+
+FORCES = ["VANDERWAALS", "ELECTROSTATIC"]
+END = "TOTAL"
+COL_KEYWORD = "ENERGY"
+ERR_TOLLERANCE = 0.001
+RDKIT_ENERGY_UNIT = unit.kilocalories_per_mole
+
+RDKIT_FORCE_UNIT = unit.Unit({unit.BaseUnit(base_dim=unit.BaseDimension("length"), name="nanometer", symbol="nm"): -1.0, unit.BaseUnit(base_dim=unit.BaseDimension("amount"), name="mole", symbol="mol"): -1.0, unit.ScaledUnit(factor=1.0, master=unit.gram*unit.nanometer**2/(unit.picosecond**2), name='kilojoule', symbol='kJ'): 1.0})
+
+
+def _parse_rdkit_output(rdkit_cout: str) -> Dict[str, List[str]]:
+    """
+    Parse RDKIT HIGH_VERBOSITY output to command line and return
+    dictionary of rows per energy.
+
+    E.g.,
+    'V A N   D E R   W A A L S\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n',
+    ...
+
+    Returns {"VANDERWAALS": [
+    'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n',
+    ]}
+
+    """
+    parse = defaultdict(list)
+    collect = False
+    cur_energy = ""
+    
+    for r in rdkit_cout:
+        if not r:
+            continue
+        if r.replace(" ", "") in FORCES:
+            cur_energy = r
+            collect = True
+        elif END in r:
+            collect = False
+        elif collect:
+            parse[cur_energy].append(r)
+    return parse
+
+
+def _get_rdkit_cout(smile: str) -> str:
+
+
+    out = subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), 'get_properties.py'),  smile], capture_output=True, text=True)
+    if not out.stdout:
+        raise Exception(out.stderr)
+
+
+    return out.stdout
+
+
+def get_energy_contributions(mol )-> Dict[int, float]:
+    """
+    E.g.,  
+    'V A N   D E R   W A A L S\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    C  #5        6   64      4.711    -0.033    3.936    0.063\n',
+     'O  #1    C  #6        6    1      4.977    -0.020    3.771    0.068\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n']
+
+    'E L E C T R O S T A T I C\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    C  #5        6   64      4.711    -0.033    3.936    0.063\n',
+     'O  #1    C  #6        6    1      4.977    -0.020    3.771    0.068\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n']
+
+    Returns
+    {1: ..., 2: ..., 3:..}
+    """
+    smile = mol.to_smiles()
+
+    if not isinstance(mol, Mol):
+        try:
+            mol = mol.to_rdkit() # try converting to rdkit
+        except:
+            raise Exception(f"Object of type {type(mol)} does not support `rdkit`")
+
+    rdkit_cout = _get_rdkit_cout(smile)
+    rdkit_cout = rdkit_cout.split("\n")
+
+
+    parse = _parse_rdkit_output(rdkit_cout)
+    expected_tot_en = float(rdkit_cout[-2]) # last output is always total energy
+    
+    energy_index = -1
+    tot_en = 0
+    
+    atoms = defaultdict(float)
+    energies = {k: [] for k in parse.keys()}
+    for k, rows in parse.items():
+        for r in rows:
+            if COL_KEYWORD in r:
+                energy_index = r.split().index(COL_KEYWORD) + 2
+      
+            elif energy_index > 0 and "#" in r:
+                energy = float(r.split()[energy_index])
+                energies[k].append(energy)
+                atom_indexes = [int(x.replace("#", "")) for x in  re.findall("#\d+", r)]
+                
+                # energy contribution only for first atom?
+                atoms[atom_indexes[0]-1] += energy
+                tot_en += energy
+    
+    if not math.isclose(tot_en, expected_tot_en, rel_tol=ERR_TOLLERANCE) or not math.isclose(sum(atoms.values()), expected_tot_en, rel_tol=ERR_TOLLERANCE):
+        raise Exception(f"Total energy {en} does not correspond to expected {expected_tot_en}")
+    return atoms
+
+def get_energy_and_derivative_from_conformers(m, poses, angle_term=True, bond_term=True, oop_term=True,
+                                              bend_term=True, torsion_term=True, vdw_term=True, ele_term=True):
+    m2 = Chem.AddHs(m)
+    AllChem.EmbedMolecule(m2)
+    AllChem.MMFFOptimizeMolecule(m2)
+    pr = ff.MMFFGetMoleculeProperties(m2)
+
+    pr.SetMMFFAngleTerm(angle_term)
+    pr.SetMMFFBondTerm(bond_term)
+    pr.SetMMFFOopTerm(oop_term)
+    pr.SetMMFFStretchBendTerm(bend_term)
+    pr.SetMMFFTorsionTerm(torsion_term)
+    pr.SetMMFFVdWTerm(vdw_term)
+    pr.SetMMFFVdWTerm(ele_term)
+    
+    mmff = ff.MMFFGetMoleculeForceField(m2,pr)
+    
+    out = list(map(lambda pos: get_energy_and_derivative_from_conformer(mmff, pos), poses))
+    return [x[0] for x in out], [x[1] for x in out]
+
+
+def get_energy_and_derivative_from_conformer(mmff, pos):
+    energy = mmff.CalcEnergy(pos)
+    grad = mmff.CalcGrad(pos)
+    return energy, grad

--- a/espaloma/graphs/graph.py
+++ b/espaloma/graphs/graph.py
@@ -3,9 +3,9 @@
 # =============================================================================
 import abc
 import io
-import openff.toolkit
 
 import espaloma as esp
+import openff.toolkit
 
 
 # =============================================================================
@@ -69,11 +69,12 @@ class Graph(BaseGraph):
         self.heterograph = heterograph
 
     def save(self, path):
-        import os
         import json
+        import os
+
         import dgl
 
-        os.mkdir(path)
+        os.makedirs(path)
         dgl.save_graphs(path + "/homograph.bin", [self.homograph])
         dgl.save_graphs(path + "/heterograph.bin", [self.heterograph])
         with open(path + "/mol.json", "w") as f_handle:
@@ -82,6 +83,7 @@ class Graph(BaseGraph):
     @classmethod
     def load(cls, path):
         import json
+
         import dgl
 
         homograph = dgl.load_graphs(path + "/homograph.bin")[0][0]

--- a/espaloma/graphs/legacy_force_field.py
+++ b/espaloma/graphs/legacy_force_field.py
@@ -81,6 +81,10 @@ class LegacyForceField:
         elif "openff" in self.forcefield:
             self._prepare_openff()
 
+        elif "mmff" in self.forcefield:
+            # do nothing for now
+            pass
+
         else:
             raise NotImplementedError
 
@@ -134,6 +138,34 @@ class LegacyForceField:
         self._str_2_idx = str_2_idx
         self._idx_2_str = idx_2_str
 
+    def _type_mmff(self, g):
+        """Type a molecular graph using rdkit implementation of mmff94 force field."""
+        # assert the forcefield is indeed of gaff family
+        assert "mmff" in self.forcefield
+
+        # make sure mol is in openff.toolkit format `
+        mol = g.mol
+
+        from rdkit.Chem import AllChem
+        from rdkit import Chem
+
+        SM = mol.to_smiles()
+        m = Chem.MolFromSmiles(SM)
+        m2=Chem.AddHs(m)
+
+        import rdkit.Chem.rdForceFieldHelpers as ff
+        mmff = ff.MMFFGetMoleculeProperties(m2)
+
+        mmff_types = [mmff.GetMMFFAtomType(i) for i in range(m2.GetNumAtoms())]
+
+        # put types into graph object
+        if g is None: # really needed?
+            g = esp.Graph(mol)
+
+        g.nodes["n1"].data["legacy_typing"] = torch.tensor(mmff_types)
+
+        return g
+    
     def _type_gaff(self, g):
         """Type a molecular graph using gaff force fields."""
         # assert the forcefield is indeed of gaff family
@@ -730,6 +762,9 @@ class LegacyForceField:
         """Type a molecular graph."""
         if "gaff" in self.forcefield:
             return self._type_gaff(g)
+        
+        elif "mmff" in self.forcefield:
+            return self._type_mmff(g)
 
         else:
             raise NotImplementedError

--- a/espaloma/graphs/legacy_force_field.py
+++ b/espaloma/graphs/legacy_force_field.py
@@ -147,16 +147,11 @@ class LegacyForceField:
         mol = g.mol
 
         from rdkit.Chem import AllChem
-        from rdkit import Chem
-
-        SM = mol.to_smiles()
-        m = Chem.MolFromSmiles(SM)
-        m2=Chem.AddHs(m)
-
         import rdkit.Chem.rdForceFieldHelpers as ff
-        mmff = ff.MMFFGetMoleculeProperties(m2)
+        mol = mol.to_rdkit()
+        mmff = ff.MMFFGetMoleculeProperties(mol)
 
-        mmff_types = [mmff.GetMMFFAtomType(i) for i in range(m2.GetNumAtoms())]
+        mmff_types = [mmff.GetMMFFAtomType(i) for i in range(mol.GetNumAtoms())]
 
         # put types into graph object
         if g is None: # really needed?


### PR DESCRIPTION
Hi,
I added this feature.

I have verified that the experiment you show in fig. 2 of the paper reaches 98% accuracy on ZINC with this typing.
(I had an initial bug related to atom ordering which is solved by using the `openff` method `.to_rdkit()` which give a perfect matching)

Hope it can be useuful.

Best,

P.