### PR TITLE
Adding second class functions

### DIFF
--- a/espaloma/data/get_properties.py
+++ b/espaloma/data/get_properties.py
@@ -1,0 +1,32 @@
+import io
+import logging
+import os
+import sys
+import time
+from contextlib import redirect_stdout
+from io import StringIO  # Python 3
+from multiprocessing import Process
+
+import rdkit.Chem.rdForceFieldHelpers as ff
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+if __name__ == '__main__':
+    smile = sys.argv[1]
+    m = Chem.MolFromSmiles(smile)
+
+    m2 = Chem.AddHs(m)
+    AllChem.EmbedMolecule(m2)
+    AllChem.MMFFOptimizeMolecule(m2)
+    pr = ff.MMFFGetMoleculeProperties(m2)
+
+    pr.SetMMFFAngleTerm(False)
+    pr.SetMMFFBondTerm(False)
+    pr.SetMMFFOopTerm(False)
+    pr.SetMMFFStretchBendTerm(False)
+    pr.SetMMFFTorsionTerm(False)
+
+    pr.SetMMFFVerbosity(2)
+
+    mmff = ff.MMFFGetMoleculeForceField(m2,pr)
+    print(mmff.CalcEnergy())

--- a/espaloma/data/rdkit_utils.py
+++ b/espaloma/data/rdkit_utils.py
@@ -1,0 +1,168 @@
+import io
+import logging
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from contextlib import redirect_stdout
+from io import StringIO  # Python 3
+from multiprocessing import Process
+from typing import Dict, List
+
+import rdkit
+import rdkit.Chem.rdForceFieldHelpers as ff
+from openmm import unit
+from rdkit import Chem
+from rdkit.Chem import AllChem
+from rdkit.Chem.rdchem import Mol
+
+FORCES = ["VANDERWAALS", "ELECTROSTATIC"]
+END = "TOTAL"
+COL_KEYWORD = "ENERGY"
+ERR_TOLLERANCE = 0.001
+RDKIT_ENERGY_UNIT = unit.kilocalories_per_mole
+
+RDKIT_FORCE_UNIT = unit.Unit({unit.BaseUnit(base_dim=unit.BaseDimension("length"), name="nanometer", symbol="nm"): -1.0, unit.BaseUnit(base_dim=unit.BaseDimension("amount"), name="mole", symbol="mol"): -1.0, unit.ScaledUnit(factor=1.0, master=unit.gram*unit.nanometer**2/(unit.picosecond**2), name='kilojoule', symbol='kJ'): 1.0})
+
+
+def _parse_rdkit_output(rdkit_cout: str) -> Dict[str, List[str]]:
+    """
+    Parse RDKIT HIGH_VERBOSITY output to command line and return
+    dictionary of rows per energy.
+
+    E.g.,
+    'V A N   D E R   W A A L S\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n',
+    ...
+
+    Returns {"VANDERWAALS": [
+    'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n',
+    ]}
+
+    """
+    parse = defaultdict(list)
+    collect = False
+    cur_energy = ""
+    
+    for r in rdkit_cout:
+        if not r:
+            continue
+        if r.replace(" ", "") in FORCES:
+            cur_energy = r
+            collect = True
+        elif END in r:
+            collect = False
+        elif collect:
+            parse[cur_energy].append(r)
+    return parse
+
+
+def _get_rdkit_cout(smile: str) -> str:
+
+
+    out = subprocess.run([sys.executable, os.path.join(os.path.dirname(__file__), 'get_properties.py'),  smile], capture_output=True, text=True)
+    if not out.stdout:
+        raise Exception(out.stderr)
+
+
+    return out.stdout
+
+
+def get_energy_contributions(mol )-> Dict[int, float]:
+    """
+    E.g.,  
+    'V A N   D E R   W A A L S\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    C  #5        6   64      4.711    -0.033    3.936    0.063\n',
+     'O  #1    C  #6        6    1      4.977    -0.020    3.771    0.068\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n']
+
+    'E L E C T R O S T A T I C\n',
+     '\n',
+     '------ATOMS------   ATOM TYPES                                 WELL\n',
+     '  I        J          I    J    DISTANCE   ENERGY     R*      DEPTH\n',
+     '--------------------------------------------------------------------\n',
+     'O  #1    C  #4        6   63      3.752    -0.056    3.936    0.063\n',
+     'O  #1    C  #5        6   64      4.711    -0.033    3.936    0.063\n',
+     'O  #1    C  #6        6    1      4.977    -0.020    3.771    0.068\n',
+     'O  #1    N  #7        6   81      5.902    -0.006    3.621    0.074\n']
+
+    Returns
+    {1: ..., 2: ..., 3:..}
+    """
+    smile = mol.to_smiles()
+
+    if not isinstance(mol, Mol):
+        try:
+            mol = mol.to_rdkit() # try converting to rdkit
+        except:
+            raise Exception(f"Object of type {type(mol)} does not support `rdkit`")
+
+    rdkit_cout = _get_rdkit_cout(smile)
+    rdkit_cout = rdkit_cout.split("\n")
+
+
+    parse = _parse_rdkit_output(rdkit_cout)
+    expected_tot_en = float(rdkit_cout[-2]) # last output is always total energy
+    
+    energy_index = -1
+    tot_en = 0
+    
+    atoms = defaultdict(float)
+    energies = {k: [] for k in parse.keys()}
+    for k, rows in parse.items():
+        for r in rows:
+            if COL_KEYWORD in r:
+                energy_index = r.split().index(COL_KEYWORD) + 2
+      
+            elif energy_index > 0 and "#" in r:
+                energy = float(r.split()[energy_index])
+                energies[k].append(energy)
+                atom_indexes = [int(x.replace("#", "")) for x in  re.findall("#\d+", r)]
+                
+                # energy contribution only for first atom?
+                atoms[atom_indexes[0]-1] += energy
+                tot_en += energy
+    
+    if not math.isclose(tot_en, expected_tot_en, rel_tol=ERR_TOLLERANCE) or not math.isclose(sum(atoms.values()), expected_tot_en, rel_tol=ERR_TOLLERANCE):
+        raise Exception(f"Total energy {en} does not correspond to expected {expected_tot_en}")
+    return atoms
+
+def get_energy_and_derivative_from_conformers(m, poses, angle_term=True, bond_term=True, oop_term=True,
+                                              bend_term=True, torsion_term=True, vdw_term=True, ele_term=True):
+    m2 = Chem.AddHs(m)
+    AllChem.EmbedMolecule(m2)
+    AllChem.MMFFOptimizeMolecule(m2)
+    pr = ff.MMFFGetMoleculeProperties(m2)
+
+    pr.SetMMFFAngleTerm(angle_term)
+    pr.SetMMFFBondTerm(bond_term)
+    pr.SetMMFFOopTerm(oop_term)
+    pr.SetMMFFStretchBendTerm(bend_term)
+    pr.SetMMFFTorsionTerm(torsion_term)
+    pr.SetMMFFVdWTerm(vdw_term)
+    pr.SetMMFFVdWTerm(ele_term)
+    
+    mmff = ff.MMFFGetMoleculeForceField(m2,pr)
+    
+    out = list(map(lambda pos: get_energy_and_derivative_from_conformer(mmff, pos), poses))
+    return [x[0] for x in out], [x[1] for x in out]
+
+
+def get_energy_and_derivative_from_conformer(mmff, pos):
+    energy = mmff.CalcEnergy(pos)
+    grad = mmff.CalcGrad(pos)
+    return energy, grad

--- a/espaloma/graphs/graph.py
+++ b/espaloma/graphs/graph.py
@@ -3,9 +3,9 @@
 # =============================================================================
 import abc
 import io
-import openff.toolkit
 
 import espaloma as esp
+import openff.toolkit
 
 
 # =============================================================================
@@ -69,11 +69,12 @@ class Graph(BaseGraph):
         self.heterograph = heterograph
 
     def save(self, path):
-        import os
         import json
+        import os
+
         import dgl
 
-        os.mkdir(path)
+        os.makedirs(path)
         dgl.save_graphs(path + "/homograph.bin", [self.homograph])
         dgl.save_graphs(path + "/heterograph.bin", [self.heterograph])
         with open(path + "/mol.json", "w") as f_handle:
@@ -82,6 +83,7 @@ class Graph(BaseGraph):
     @classmethod
     def load(cls, path):
         import json
+
         import dgl
 
         homograph = dgl.load_graphs(path + "/homograph.bin")[0][0]

--- a/espaloma/graphs/utils/generate_oops.py
+++ b/espaloma/graphs/utils/generate_oops.py
@@ -1,0 +1,67 @@
+import dgl
+import numpy as np
+import torch
+
+from ..graph import Graph
+from .offmol_indices import out_of_plane_indices
+
+
+def generate_oops(g: Graph):
+    """
+    Method to regenerate the improper nodes according to the specified
+    method of permuting the impropers. Modifies the esp.Graph's heterograph
+    in place and returns the new heterograph.
+    NOTE: This will clear the data on all n4_improper nodes, including
+    previously generated improper from JanossyPoolingImproper.
+    """
+
+    ## First get rid of the old nodes/edges
+    hg = g.heterograph
+
+    # Extract representation data that closely resembles the original data_dict
+    representation_data_dict = {}
+    for edge_type in hg.canonical_etypes:
+        src_type, edge_name, dst_type = edge_type
+        src, dst = hg.edges(etype=edge_type)
+        representation_data_dict[edge_type] = (src, dst)
+    
+    idxs = out_of_plane_indices(g.mol)
+
+    ## New edges b/n oop permuts and n1 nodes
+    permut_ids = np.arange(idxs.shape[0])
+    for i in range(4):
+        n1_ids = idxs[:, i]
+
+        # edge from improper node to n1 node
+        outgoing_etype = ("n4_oop", f"n4_oop_has_{i}_n1", "n1")
+        
+        representation_data_dict[outgoing_etype] = (permut_ids, n1_ids)
+
+        # edge from n1 to improper
+        incoming_etype = ("n1", f"n1_as_{i}_in_n4_oop", "n4_oop")
+        representation_data_dict[incoming_etype] = (n1_ids, permut_ids)
+
+
+    ## New edges b/n improper permuts and the graph (for global pooling)
+    # edge from improper node to graph
+    
+    outgoing_etype = ("n4_oop", f"n4_oop_in_g", "g")
+    representation_data_dict[outgoing_etype] = (permut_ids, np.zeros_like(permut_ids))
+
+    # edge from graph to improper nodes
+    incoming_etype = ("g", "g_has_n4_oop", "n4_oop")
+    representation_data_dict[incoming_etype] = (np.zeros_like(permut_ids), permut_ids)
+    
+
+
+    new_hg = dgl.heterograph(representation_data_dict)
+    for node_type in hg.ntypes:
+        ndata = hg.nodes[node_type].data
+        for k in ndata.keys():
+            new_hg.nodes[node_type].data[k] = ndata[k]
+
+    new_hg.nodes["n4_oop"].data["idxs"] = torch.tensor(idxs)
+
+    g.heterograph = new_hg
+
+    return g  # hg

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -102,7 +102,7 @@ def out_of_plane_indices(
     improper_def allows for choosing which atom will be the central atom in the
     permutations:
     smirnoff: central atom is listed first
-    espaloma: central atom is listed second
+    
 
     Addtionally, for smirnoff, only take the subset of atoms that corresponds
     to the ccw traversal of connected atoms.

--- a/espaloma/graphs/utils/offmol_indices.py
+++ b/espaloma/graphs/utils/offmol_indices.py
@@ -92,3 +92,26 @@ def improper_torsion_indices(
         return np.array(idx_permuts)
     else:
         raise ValueError(f"Unknown value for improper_def: {improper_def}")
+
+
+def out_of_plane_indices(
+    offmol: Molecule
+) -> np.ndarray:
+    """ "[*:1]~[X3:2](~[*:3])~[*:4]" matches (_all_improper_torsion_indices returns "[*:1]~[*:2](~[*:3])~[*:4]" matches)
+
+    improper_def allows for choosing which atom will be the central atom in the
+    permutations:
+    smirnoff: central atom is listed first
+    espaloma: central atom is listed second
+
+    Addtionally, for smirnoff, only take the subset of atoms that corresponds
+    to the ccw traversal of connected atoms.
+
+    Notes
+    -----
+    Motivation: offmol.impropers returns a large number of impropers, and we may wish to restrict this number.
+    May update this filter definition based on discussion in https://github.com/openff.toolkit/openff.toolkit/issues/746
+    """
+    improper_smarts = "[*:1]~[X3:2](~[*:3])~[*:4]"
+    mol_idxs = offmol.chemical_environment_matches(improper_smarts)
+    return np.array(mol_idxs)

--- a/espaloma/graphs/utils/oop_indices.py
+++ b/espaloma/graphs/utils/oop_indices.py
@@ -1,0 +1,44 @@
+import numpy as np
+from openff.toolkit.topology import Molecule
+
+
+def atom_indices(offmol: Molecule) -> np.ndarray:
+    return np.array([a.molecule_atom_index for a in offmol.atoms])
+
+
+def bond_indices(offmol: Molecule) -> np.ndarray:
+    return np.array([(b.atom1_index, b.atom2_index) for b in offmol.bonds])
+
+
+def angle_indices(offmol: Molecule) -> np.ndarray:
+    return np.array(
+        sorted(
+            [
+                tuple([atom.molecule_atom_index for atom in angle])
+                for angle in offmol.angles
+            ]
+        )
+    )
+
+
+
+def out_of_plane_indices(
+    offmol: Molecule, improper_def="espaloma"
+) -> np.ndarray:
+    """ "[*:1]~[X3:2](~[*:3])~[*:4]" matches (_all_improper_torsion_indices returns "[*:1]~[*:2](~[*:3])~[*:4]" matches)
+
+    improper_def allows for choosing which atom will be the central atom in the
+    permutations:
+    smirnoff: central atom is listed first
+    espaloma: central atom is listed second
+
+    Addtionally, for smirnoff, only take the subset of atoms that corresponds
+    to the ccw traversal of connected atoms.
+
+    Notes
+    -----
+    Motivation: offmol.impropers returns a large number of impropers, and we may wish to restrict this number.
+    May update this filter definition based on discussion in https://github.com/openff.toolkit/openff.toolkit/issues/746
+    """
+    breakpoint()
+    pass

--- a/espaloma/graphs/utils/regenerate_impropers.py
+++ b/espaloma/graphs/utils/regenerate_impropers.py
@@ -2,8 +2,8 @@ import dgl
 import numpy as np
 import torch
 
-from .offmol_indices import improper_torsion_indices
 from ..graph import Graph
+from .offmol_indices import improper_torsion_indices
 
 
 def regenerate_impropers(g: Graph, improper_def="smirnoff"):
@@ -54,7 +54,7 @@ def regenerate_impropers(g: Graph, improper_def="smirnoff"):
     )
 
     hg.nodes["n4_improper"].data["idxs"] = torch.tensor(idxs)
-
+    
     g.heterograph = hg
 
     return g  # hg

--- a/espaloma/mm/angle.py
+++ b/espaloma/mm/angle.py
@@ -2,6 +2,7 @@
 # IMPORTS
 # =============================================================================
 import espaloma as esp
+import torch
 
 
 # =============================================================================
@@ -54,11 +55,26 @@ def harmonic_angle_mmff(x, k, eq):
     # NOTE:
     # the constant 0.5 is included here but not in the functional forms
 
-    # NOTE:
+
     
-    return 0.043844 * esp.mm.functional.cubic_expansion(x=x, k=k, eq=eq)
+    eq3_mmff = 0.043844 * esp.mm.functional.cubic_expansion(x=x, k=k, eq=eq)
+    eq4_mmff = 143.9325 * esp.mm.functional.near_linear_expansion(x=x, k=k, eq=eq)
+    
+    return torch.where(is_nearlinear(x, eq), eq4_mmff, eq3_mmff)
+
+def is_nearlinear(x, eq):
+    """
+    TODO (gianscarpe): fix with correct formula
+    Implement MMFF definition of near-linear angles (related to eq3 and eq 5)
+
+    """
+    delta = ((x - eq))
+
+    return torch.all((delta < torch.pi) * (delta > torch.pi/2), 1)[:, None].repeat(1, delta.shape[1])
 
 
+def harmonic_stretch_bend_mmff(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):
+    return 2.51210 * esp.mm.functional.stretch_bend_expansion(x=x, k=k, eq=eq, eq_ij=eq_ij, eq_kj=eq_kj, x_ij=x_ij, x_kj=x_kj)
 
 def linear_mixture_angle(x, coefficients, phases):
     """Angle energy with Linear basis function.

--- a/espaloma/mm/angle.py
+++ b/espaloma/mm/angle.py
@@ -34,7 +34,7 @@ def harmonic_angle(x, k, eq):
     return 0.5 * esp.mm.functional.harmonic(x=x, k=k, eq=eq)
 
 
-def harmonic_angle_mmff(x, k, eq):
+def harmonic_angle_mmff(x, k, eq, lin):
     """Harmonic angle energy.
 
     Parameters
@@ -60,26 +60,15 @@ def harmonic_angle_mmff(x, k, eq):
     eq3_mmff = 0.043844 * esp.mm.functional.cubic_expansion(x=x, k=k, eq=eq)
     eq4_mmff = 143.9325 * esp.mm.functional.near_linear_expansion(x=x, k=k, eq=eq)
     
-    return torch.where(is_nearlinear(x, eq), eq4_mmff, eq3_mmff)
+    return torch.where(lin, eq4_mmff, eq3_mmff)
 
 
 def oop_bend_mmff(x, k):
     return .043844 * esp.mm.functional.oop_expansion(x=x, k=k)
 
 
-def is_nearlinear(x, eq):
-    """
-    TODO (gianscarpe): fix with correct formula
-    Implement MMFF definition of near-linear angles (related to eq3 and eq 5)
-
-    """
-    theta = x
-    
-    return torch.all((theta == torch.pi), 1)[:, None].repeat(1, theta.shape[1])
-
-
-def harmonic_stretch_bend_mmff(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):
-    return 2.51210 * esp.mm.functional.stretch_bend_expansion(x=x, k=k, eq=eq, eq_ij=eq_ij, eq_kj=eq_kj, x_ij=x_ij, x_kj=x_kj)
+def harmonic_stretch_bend_mmff(x, k, eq, eq_ij, eq_kj, x_ij, x_kj,is_linear):
+    return 2.51210 * esp.mm.functional.stretch_bend_expansion(x=x, k=k, eq=eq, eq_ij=eq_ij, eq_kj=eq_kj, x_ij=x_ij, x_kj=x_kj, is_linear=is_linear)
 
 
 

--- a/espaloma/mm/angle.py
+++ b/espaloma/mm/angle.py
@@ -33,6 +33,33 @@ def harmonic_angle(x, k, eq):
     return 0.5 * esp.mm.functional.harmonic(x=x, k=k, eq=eq)
 
 
+def harmonic_angle_mmff(x, k, eq):
+    """Harmonic angle energy.
+
+    Parameters
+    ----------
+    x : `torch.Tensor`, `shape = (batch_size, 1)`
+        angle value
+    k : `torch.Tensor`, `shape = (batch_size, 1)`
+        force constant
+    eq : `torch.Tensor`, `shape = (batch_size, 1)`
+        equilibrium angle
+
+    Returns
+    -------
+    u : `torch.Tensor`, `shape = (batch_size, 1)`
+        energy
+
+    """
+    # NOTE:
+    # the constant 0.5 is included here but not in the functional forms
+
+    # NOTE:
+    
+    return 0.043844 * esp.mm.functional.cubic_expansion(x=x, k=k, eq=eq)
+
+
+
 def linear_mixture_angle(x, coefficients, phases):
     """Angle energy with Linear basis function.
 

--- a/espaloma/mm/angle.py
+++ b/espaloma/mm/angle.py
@@ -68,9 +68,9 @@ def is_nearlinear(x, eq):
     Implement MMFF definition of near-linear angles (related to eq3 and eq 5)
 
     """
-    delta = ((x - eq))
+    theta = x
 
-    return torch.all((delta < torch.pi) * (delta > torch.pi/2), 1)[:, None].repeat(1, delta.shape[1])
+    return torch.all((theta < torch.pi) * (theta > torch.pi/2), 1)[:, None].repeat(1, theta.shape[1])
 
 
 def harmonic_stretch_bend_mmff(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):

--- a/espaloma/mm/angle.py
+++ b/espaloma/mm/angle.py
@@ -62,6 +62,11 @@ def harmonic_angle_mmff(x, k, eq):
     
     return torch.where(is_nearlinear(x, eq), eq4_mmff, eq3_mmff)
 
+
+def oop_bend_mmff(x, k):
+    return .043844 * esp.mm.functional.oop_expansion(x=x, k=k)
+
+
 def is_nearlinear(x, eq):
     """
     TODO (gianscarpe): fix with correct formula
@@ -69,12 +74,14 @@ def is_nearlinear(x, eq):
 
     """
     theta = x
-
-    return torch.all((theta < torch.pi) * (theta > torch.pi/2), 1)[:, None].repeat(1, theta.shape[1])
+    
+    return torch.all((theta == torch.pi), 1)[:, None].repeat(1, theta.shape[1])
 
 
 def harmonic_stretch_bend_mmff(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):
     return 2.51210 * esp.mm.functional.stretch_bend_expansion(x=x, k=k, eq=eq, eq_ij=eq_ij, eq_kj=eq_kj, x_ij=x_ij, x_kj=x_kj)
+
+
 
 def linear_mixture_angle(x, coefficients, phases):
     """Angle energy with Linear basis function.

--- a/espaloma/mm/bond.py
+++ b/espaloma/mm/bond.py
@@ -33,6 +33,32 @@ def harmonic_bond(x, k, eq):
     return 0.5 * esp.mm.functional.harmonic(x=x, k=k, eq=eq)
 
 
+def harmonic_bond_mmff(x, k, eq):
+    """Harmonic bond energy.
+
+    Parameters
+    ----------
+    x : `torch.Tensor`, `shape = (batch_size, 1)`
+        bond length
+    k : `torch.Tensor`, `shape = (batch_size, 1)`
+        force constant
+    eq : `torch.Tensor`, `shape = (batch_size, 1)`
+        equilibrium bond length
+
+    Returns
+    -------
+    u : `torch.Tensor`, `shape = (batch_size, 1)`
+        energy
+
+    """
+    # NOTE:
+    # the constant is included here but not in the functional forms
+
+    return (143.9325 * esp.mm.functional.quartic_expansion(x=x, k=k, eq=eq)).float()
+
+
+
+
 def gaussian_bond(x, coefficients):
     """Bond energy with Gaussian basis function."""
     return esp.mm.functional.gaussian(

--- a/espaloma/mm/energy.py
+++ b/espaloma/mm/energy.py
@@ -58,7 +58,8 @@ def apply_stretch_bend(nodes, suffix):
             eq_ij=nodes.data['eq2_ij'],
             eq_kj=nodes.data['eq2_kj'],
             x_ij=nodes.data['x2_ij'],
-            x_kj=nodes.data['x2_kj']
+            x_kj=nodes.data['x2_kj'],
+            is_linear=nodes.data['lin']
         )
     }
 
@@ -74,6 +75,7 @@ def apply_angle(nodes, suffix=""):
     }
 
 def apply_angle_mmff(nodes, suffix=""):
+
     """Angle energy in nodes."""
     return {
         "u%s"
@@ -81,6 +83,7 @@ def apply_angle_mmff(nodes, suffix=""):
             x=nodes.data["x"],
             k=nodes.data["k%s" % suffix],
             eq=nodes.data["eq%s" % suffix],
+            lin=nodes.data["lin"]
         )
     }
 

--- a/espaloma/mm/energy.py
+++ b/espaloma/mm/energy.py
@@ -43,6 +43,10 @@ def apply_bond_mmff(nodes, suffix=""):
     #         )
     #     }
 
+def stretch_bend(self):
+    """
+    TODO copy from contribution 2 and 3 into eq 5
+    """
 
 def apply_angle(nodes, suffix=""):
     """Angle energy in nodes."""
@@ -171,7 +175,62 @@ def apply_torsion(nodes, suffix=""):
         }
 
 
+def apply_torsion(nodes, suffix=""):
+    """Torsion energy in nodes."""
+    return {
+        "u%s"
+        % suffix: esp.mm.torsion.periodic_torsion(
+            x=nodes.data["x"],
+            k=nodes.data["k%s" % suffix],
+        )
+    }
+
+def apply_torsion_mmff(nodes, suffix=""):
+    """Torsion energy in nodes."""
+    return {
+        "u%s"
+        % suffix: esp.mm.torsion.periodic_torsion_mmff(
+            x=nodes.data["x"],
+            k=nodes.data["k%s" % suffix],
+        )
+    }
+
+
+
+
 def apply_improper_torsion(nodes, suffix=""):
+    """Improper torsion energy in nodes."""
+    if (
+        "phases%s" % suffix in nodes.data
+        and "periodicity%s" % suffix in nodes.data
+    ):
+        return {
+            "u%s"
+            % suffix: esp.mm.torsion.periodic_torsion(
+                x=nodes.data["x"],
+                k=nodes.data["k%s" % suffix],
+                phases=nodes.data["phases%s" % suffix],
+                periodicity=nodes.data["periodicity%s" % suffix],
+            )
+        }
+
+    else:
+        n_multi = nodes.data["k%s" % suffix].shape[-1]
+        periodicity=list(range(1, n_multi+1))
+        phases=[0.0 for _ in range(n_multi)]
+        breakpoint()
+        return {
+            "u%s"
+            % suffix: esp.mm.torsion.periodic_torsion(
+                x=nodes.data["x"],
+                k=nodes.data["k%s" % suffix],
+                phases=phases,
+                periodicity=periodicity,
+            )
+        }
+
+
+def apply_improper_torsion_mmff(nodes, suffix=""):
     """Improper torsion energy in nodes."""
     if (
         "phases%s" % suffix in nodes.data
@@ -484,7 +543,7 @@ def energy_in_graph_mmff(
 
     if g.number_of_nodes("n4") > 0 and "n4" in terms:
         g.apply_nodes(
-            lambda node: apply_torsion(node, suffix=suffix),
+            lambda node: apply_torsion_mmff(node, suffix=suffix),
             ntype="n4",
         )
 
@@ -551,6 +610,7 @@ def energy_in_graph_mmff(
         cross_reducer="sum",
     )
 
+    
     g.apply_nodes(
         lambda node: {
             "u%s"
@@ -563,12 +623,13 @@ def energy_in_graph_mmff(
         ntype="g",
     )
 
+    breakpoint()
     if "u0" in g.nodes["g"].data:
         g.apply_nodes(
             lambda node: {"u": node.data["u"] + node.data["u0"]},
             ntype="g",
         )
-
+    
     return g
 
 

--- a/espaloma/mm/energy.py
+++ b/espaloma/mm/energy.py
@@ -209,6 +209,16 @@ def apply_torsion_mmff(nodes, suffix=""):
         )
     }
 
+def apply_oop_mmff(nodes, suffix=""):
+    """Torsion energy in nodes."""
+    return {
+        "u%s"
+        % suffix: esp.mm.angle.oop_bend_mmff(
+            x=nodes.data["x"],
+            k=nodes.data["k%s" % suffix],
+        )
+    }
+
 
 
 
@@ -559,7 +569,7 @@ def energy_in_graph_mmff(
         ijk = g.nodes['n3'].data['idxs']
         ij = ijk[:, :2]
         
-        breakpoint()
+
 
         # Extract x and eq by indexing `g.nodes['n2']`
         mask = torch.all(torch.eq(g.nodes['n2'].data['idxs'][:, None, :], ij), dim=-1)
@@ -591,27 +601,18 @@ def energy_in_graph_mmff(
             ntype="n4",
         )
 
+    
     if g.number_of_nodes("n4_improper") > 0 and "n4_improper" in terms:
         g.apply_nodes(
             lambda node: apply_improper_torsion(node, suffix=suffix),
             ntype="n4_improper",
         )
-
-    # if g.number_of_nodes("nonbonded") > 0 and "nonbonded" in terms:
-    #     g.apply_nodes(
-    #         lambda node: apply_nonbonded(node, suffix=suffix),
-    #         ntype="nonbonded",
-    #     )
-
-    # if g.number_of_nodes("onefour") > 0 and "onefour" in terms:
-    #     g.apply_nodes(
-    #         lambda node: apply_nonbonded(
-    #             node,
-    #             suffix=suffix,
-    #             scaling=0.5,
-    #         ),
-    #         ntype="onefour",
-    #     )
+    
+    if g.number_of_nodes('n4_oop') > 0 and "n4_oop" in terms:
+        g.apply_nodes(
+            lambda node: apply_oop_mmff(node, suffix=suffix),
+            ntype="n4_oop",
+        )
 
     if "nonbonded" in terms or "onefour" in terms:
         esp.mm.nonbonded.multiply_charges(g)

--- a/espaloma/mm/functional.py
+++ b/espaloma/mm/functional.py
@@ -90,8 +90,9 @@ def quartic_expansion(x, k, eq, order=[2]):
     delta = ((x - eq))
     delta_squared =((x - eq)).pow(order[:, None, None])
     cs = -2
-    
+    breakpoint()
     out = k * delta_squared / 2 * (1 + cs * delta + 7/12 * cs**2 * delta_squared)
+    # 1 x N_atoms x 50
     return out.permute(1, 2, 0).sum(dim=-1)
 
 

--- a/espaloma/mm/functional.py
+++ b/espaloma/mm/functional.py
@@ -125,7 +125,7 @@ def quartic_expansion(x, k, eq, order=[2]):
     return out.permute(1, 2, 0).sum(dim=-1)
 
 
-def stretch_bend_expansion(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):
+def stretch_bend_expansion(x, k, eq, eq_ij, eq_kj, x_ij, x_kj, is_linear):
     """
     Eq (5) MMFF. Note that it's not applied when angle is near-linear
     """
@@ -141,7 +141,7 @@ def stretch_bend_expansion(x, k, eq, eq_ij, eq_kj, x_ij, x_kj):
     
     # Condition for eq4 to apply
     #is_linear = torch.all((delta_ijk < torch.pi) * (delta_ijk > torch.pi/2), 1)[:, None].repeat(1, delta_ijk.shape[1])
-    is_linear =esp.mm.angle.is_nearlinear(x, eq)
+
     out = ((k_ijk * delta_ij + k_kji * delta_kj) * delta_ijk) #.permute(1, 2, 0).sum(dim=-1)
     
     return torch.where(is_linear, torch.zeros_like(out), out)

--- a/espaloma/mm/functional.py
+++ b/espaloma/mm/functional.py
@@ -76,16 +76,14 @@ def cubic_expansion(x, k, eq, order=[2]):
 
 def near_linear_expansion(x, k, eq, order=[2]):
     """
-    Cubic expansion, eq (4) from Merck94
+    Near-linear angles from eq (4) from Merck94. It's basically constant
     """
     if isinstance(order, list):
         order = torch.tensor(order, device=x.device)
 
+    theta_cos = x.cos() # eq (4)
     
-    
-    delta_cos = ((x - eq)).cos()
-    
-    out = k * (1 + delta_cos)
+    out = k * (1 + theta_cos)
     return out
 
 

--- a/espaloma/mm/functional.py
+++ b/espaloma/mm/functional.py
@@ -2,9 +2,9 @@
 # IMPORTS
 # =============================================================================
 import math
-import torch
-import espaloma as esp
 
+import espaloma as esp
+import torch
 # =============================================================================
 # CONSTANTS
 # =============================================================================
@@ -57,6 +57,43 @@ def harmonic(x, k, eq, order=[2]):
         * k
         * ((x - eq)).pow(order[:, None, None]).permute(1, 2, 0).sum(dim=-1)
     )
+
+def cubic_expansion(x, k, eq, order=[2]):
+    """
+    Cubic expansion, eq (3) from Merck94
+    """
+    if isinstance(order, list):
+        order = torch.tensor(order, device=x.device)
+
+    
+    delta = ((x - eq))
+    delta_squared =((x - eq)).pow(order[:, None, None])
+    cb = -0.007
+    
+    out = k * delta_squared / 2 * (1 + cb * delta)
+    return out.permute(1, 2, 0).sum(dim=-1)
+
+
+def quartic_expansion(x, k, eq, order=[2]):
+    """
+    Eq (2) MMFF94
+
+    Delta_r = x - eq
+    k force constant md/A
+    cs A
+
+    """
+    if isinstance(order, list):
+        order = torch.tensor(order, device=x.device)
+
+    
+    delta = ((x - eq))
+    delta_squared =((x - eq)).pow(order[:, None, None])
+    cs = -2
+    
+    out = k * delta_squared / 2 * (1 + cs * delta + 7/12 * cs**2 * delta_squared)
+    return out.permute(1, 2, 0).sum(dim=-1)
+
 
 
 def periodic_fixed_phases(
@@ -185,6 +222,13 @@ def periodic(
 
     return energy
 
+def torsion_merck():
+    """
+    cos_n_theta_minus_phases multiplied by constants
+    MMFF94
+    """
+    pass
+
 
 # simple implementation
 # def harmonic(x, k, eq):
@@ -198,7 +242,6 @@ def periodic(
 #     c = ((ka * a + kb * b) / (ka + kb)) ** 2 - a ** 2 - b ** 2
 #
 #     return ka * (x - a) ** 2 + kb * (x - b) ** 2
-
 
 def lj(
     x,

--- a/espaloma/mm/functional.py
+++ b/espaloma/mm/functional.py
@@ -74,6 +74,22 @@ def cubic_expansion(x, k, eq, order=[2]):
     return out.permute(1, 2, 0).sum(dim=-1)
 
 
+def oop_expansion(x, k, order=[2]):
+    """
+    Cubic expansion, eq (3) from Merck94
+    """
+    if isinstance(order, list):
+        order = torch.tensor(order, device=x.device)
+
+
+    delta_squared = x.pow(order[:, None, None])
+    
+    out = k * delta_squared / 2
+    return out.permute(1, 2, 0).sum(dim=-1)
+
+
+
+
 def near_linear_expansion(x, k, eq, order=[2]):
     """
     Near-linear angles from eq (4) from Merck94. It's basically constant

--- a/espaloma/mm/geometry.py
+++ b/espaloma/mm/geometry.py
@@ -3,6 +3,7 @@
 # =============================================================================
 import torch
 
+
 # =============================================================================
 # UTILITY FUNCTIONS
 # =============================================================================
@@ -55,6 +56,7 @@ def _dihedral(r0, r1):
     return _angle(r0, r1)
 
 
+# TODO check
 def dihedral(
     x0: torch.Tensor, x1: torch.Tensor, x2: torch.Tensor, x3: torch.Tensor
 ) -> torch.Tensor:

--- a/espaloma/mm/geometry.py
+++ b/espaloma/mm/geometry.py
@@ -276,6 +276,7 @@ def geometry_in_graph(g):
 
     # apply geometry functions
     g.apply_nodes(apply_bond, ntype="n2")
+    
     g.apply_nodes(apply_angle, ntype="n3")
 
     if g.number_of_nodes("n4") > 0:

--- a/espaloma/mm/torsion.py
+++ b/espaloma/mm/torsion.py
@@ -41,6 +41,40 @@ def periodic_torsion(
     # assert(out.shape == (len(x), 1))
     return out
 
+def periodic_torsion_mmff(
+    x, k, periodicity=list(range(1, 4))
+):
+    """Periodic torsion potential
+
+    Parameters
+    ----------
+    x : `torch.Tensor`, `shape = (batch_size, 1)`
+        Dihedral value.
+    k : `torch.Tensor`, `shape = (batch_size, n_phases)`
+        Force constants.
+    periodicity : `torch.Tensor`, `shape = (batch_size, n_phases)`
+        Periodicities
+    phases : `torch.Tensor`, `shape = (batch_size, n_phases)`
+        Phase offsets
+
+    Returns
+    -------
+    u : `torch.Tensor`, `shape = (batch_size, 1)`
+        Energy.
+
+    """
+
+    # NOTE:
+    # 0.5 because all torsions are calculated twice
+    out = 0.5 * esp.mm.functional.periodic_mmff(
+        x=x,
+        k=k,
+        periodicity=periodicity,
+    )
+    # assert(out.shape == (len(x), 1))
+    return out
+
+
 
 def angle_angle(
     u_angle_left,

--- a/espaloma/nn/readout/janossy.py
+++ b/espaloma/nn/readout/janossy.py
@@ -1,9 +1,8 @@
 # =============================================================================
 # IMPORTS
 # =============================================================================
-import torch
-
 import espaloma as esp
+import torch
 
 
 # =============================================================================
@@ -265,10 +264,10 @@ class JanossyPoolingImproper(torch.nn.Module):
         stack_permuts = lambda nodes, p: torch.cat(
             [nodes.data[f"h{i}"] for i in p], dim=1
         )
-
+        breakpoint()
         for big_idx in self.levels:
             inner_net = getattr(self, f"sequential_{big_idx}")
-
+            
             g.apply_nodes(
                 func=lambda nodes: {
                     feature: getattr(self, f"f_out_{big_idx}_to_{feature}")(
@@ -377,6 +376,7 @@ class JanossyPoolingWithSmirnoffImproper(torch.nn.Module):
         #   following the smirnoff trefoil convention [(0, 1, 2, 3), (2, 1, 3, 0), (3, 1, 0, 2)]
         #   https://github.com/openff.toolkit/openff.toolkit/blob/166c9864de3455244bd80b2c24656bd7dda3ae2d/openff.toolkit/typing/engines/smirnoff/parameters.py#L3326-L3360
 
+        # TODO to check
         ## Set different permutations based on which definition of impropers
         ##  are being used
         permuts = [(0, 1, 2, 3), (0, 2, 3, 1), (0, 3, 1, 2)]
@@ -407,7 +407,7 @@ class JanossyPoolingWithSmirnoffImproper(torch.nn.Module):
                 },
                 ntype=big_idx,
             )
-
+        breakpoint()
         return g
 
 


### PR DESCRIPTION
Added MMFF94 functional forms
Requirements:
- ligen (for lin/near-lin angle bonds)

Major changes (functional forms)
- Added functional forms from "Merck Molecular Force Field" Thoms A. Halgren
-- Bond stretching (eq. 2)
-- Angle bending (eq. 3)
-- stretch-bend interactions (eq. 5). Note that params in eq. 2 and 3 and re-used for eq. 5
-- out-of-plane bending (eq. 6), where oop angles correspond to improper angles)
-- Torsion interactions (eq. 7)

Linear angles
- We expect the graph to have a "lin" attribute for "n3" interactions for solving between eq.3 and eq. 4 and eq. 6